### PR TITLE
Auth bug fix

### DIFF
--- a/conf/apel_rest_api.conf
+++ b/conf/apel_rest_api.conf
@@ -13,6 +13,7 @@ WSGISocketPrefix /var/run/wsgi
 WSGIDaemonProcess apel_rest python-path=/var/www/html:/usr/lib/python2.6/site-packages
 WSGIProcessGroup apel_rest
 WSGIScriptAlias / /var/www/html/apel_rest/wsgi.py
+WSGIPassAuthorization On
 
 Alias /static "/usr/lib/python2.6/site-packages/rest_framework/static"
 <Directory "/usr/lib/python2.6/site-packages/rest_framework/static">

--- a/conf/ssl.conf
+++ b/conf/ssl.conf
@@ -129,7 +129,7 @@ SSLCACertificatePath /etc/grid-security/certificates
 #   none, optional, require and optional_no_ca.  Depth is a
 #   number which specifies how deeply to verify the certificate
 #   issuer chain before deciding the certificate is not valid.
-SSLVerifyClient require
+SSLVerifyClient optional
 SSLVerifyDepth  10
 
 #   Access Control:


### PR DESCRIPTION
SSLVerifyClient switched to optional because otherwise when using tokens to access summaries you still need a X.509 certificate to connect to the server

Pass token to underlying Django server (not sure why this is needed now / how it was ommited before!)