### PR TITLE
Place static files assuming standalone use

### DIFF
--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -86,7 +86,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_ROOT = '/var/www/html/static'
-STATIC_URL = '/accounting-server/static/'
+STATIC_URL = '/static/'
 
 # debugging stuff
 LOGGING = {


### PR DESCRIPTION
- rather than linking it to a particular instance in kubernetes `/accounting-server/` referred to its deployment on https://indigo-paas.cloud.ba.infn.it/, doing it this way means it works as a stand alone deployment right out the container, but may need some extra work if deployed under another Apache server if you want it to look pretty

(I can rebase this once PR 10 is merged if needed or preferred)