### PR TITLE
Run container enhancement

### DIFF
--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,32 +1,63 @@
 #!/bin/bash
 set -eu
 
+############ MODIFY THESE VARIABLES ############# 
+
+# The password for the APEL user.
+# NEEDS POPULATING
+# EVEN IF NOT RE-DEPLOYING A DATABASE
+# As it is needed to access the deployed database
+MYSQL_PASSWORD=
+
+# A (python) list of IAM service IDs allowed to submit GET requests.
+# This bash variable needs to be interpreted by python as a list of strings
+# i.e. [\'ac2f23e0-8103-4581-8014-e0e82c486e36\']
+# NEEDS POPULATING
+ALLOWED_FOR_GET=
+
+# An IAM ID corresponding to this instance, used to validate tokens.
+# NEEDS POPULATING
+SERVER_IAM_ID=
+
+# An IAM secret corresponding to this instance, used to validate tokens.
+# NEEDS POPULATING
+SERVER_IAM_SECRET=
+
+# The Django server requires its own "secret".
+# NEDDS POPULATING
+DJANGO_SECRET_KEY=
+
+# The database root password.
+# NEEDS POPULATING if and only iff deploying database containers
+MYSQL_ROOT_PASSWORD=
+
+#################################################
+
+
 # This script corresponds to the following  version
 VERSION="1.1.0-1"
 
 function usage {
     echo "Version: $VERSION"
     echo "USAGE:"
-    echo "./run_container.sh [ -p (y)|n ] IMAGE_NAME"
+    echo "./run_container.sh [ -p (y)|n ] [ -d (y)|n ] IMAGE_NAME"
     echo ""
-    echo "    -p y: the script will pull the image from a registry."
-    echo "       n: the script will omit the docker pull command,"
+    echo "    -p y: Pull the image from a registry."
+    echo "       n: Omit the docker pull command,"
     echo "          used to run an instance of a local image."
+    echo "    -d y: Deploy the database container"
+    echo "       n: Do not deploy the database container,"
+    echo "          used when deploying an upgrade to the APEL Server container."
     echo "    -h:   Displays the message."
     exit
 }
 
-# Check arguement/option number is 1 or 3
-if [ $# -ne 1 ] && [ $# -ne 3 ]
-then
-    usage
-fi
-
 # Set defaults for options
 PULL="y"
+DATABASE="y"
 
 # Process options
-while getopts "hp:" OPT; do
+while getopts "d:hp:" OPT; do
     case $OPT in
        h) # Display the usage message
            usage
@@ -37,6 +68,15 @@ while getopts "hp:" OPT; do
                PULL=$OPTARG
            else
                echo "Invalid -p arguement: $OPTARG"
+               usage
+           fi
+       ;;
+       d) # Deploy the database
+           if [ "$OPTARG" == "y" ] || [ "$OPTARG" == "n" ]
+           then
+               DATABASE=$OPTARG
+           else
+               echo "Invalid -d arguement: $OPTARG"
                usage
            fi
        ;;
@@ -61,64 +101,34 @@ echo "Deploying $IMAGE_NAME with run_container.sh ($VERSION)"
 # If -p y, or if -p was ommited
 if [ "$PULL" == "y" ]
 then
-    echo "Pulling image: $IMAGE_NAME"
+    echo "Pulling image"
     docker pull $IMAGE_NAME
 else
-    echo "Using local image: $IMAGE_NAME"
+    echo "Using local image"
 fi
 
-echo "Deploying MySQL Container"
+if [ "$DATABASE" == "y" ]
+then
+    # Deploy the databbase
+    echo "Deploying MySQL Container"
 
-# The database root password.
-# NEEDS POPULATING
-MYSQL_ROOT_PASSWORD=
+    docker run -v /var/lib/mysql --name apel-mysql -p 3306:3306 -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" -e "MYSQL_DATABASE=apel_rest" -e "MYSQL_USER=apel" -e "MYSQL_PASSWORD=$MYSQL_PASSWORD" -d mysql:5.6
 
-# Create an APEL user
-# Do not change
-MYSQL_USER="apel"
+    #wait for apel-mysql to configure
+    sleep 30
 
-# The password for the APEL user.
-# Can be overidden
-MYSQL_PASSWORD="${MYSQL_ROOT_PASSWORD}APEL"
+    # Create schema
+    docker exec apel-mysql mysql -u root -p$MYSQL_ROOT_PASSWORD apel_rest -e "`cat schemas/cloud.sql`"
 
-# The name of the database used to store accounting data  
-# Can be overidden
-MYSQL_DATABASE="apel_rest"
-
-docker run -v /var/lib/mysql --name apel-mysql -p 3306:3306 -e "MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD" -e "MYSQL_DATABASE=$MYSQL_DATABASE" -e "MYSQL_USER=$MYSQL_USER" -e "MYSQL_PASSWORD=$MYSQL_PASSWORD" -d mysql:5.6
-
-#wait for apel-mysql to configure
-sleep 30
-
-# Create schema
-docker exec apel-mysql mysql -u root -p$MYSQL_ROOT_PASSWORD apel_rest -e "`cat schemas/cloud.sql`"
-
-# Partition tables
-docker exec apel-mysql mysql -u root -p$MYSQL_ROOT_PASSWORD apel_rest -e "`cat schemas/cloud-extra.sql`"
-
-echo "Done"
+    # Partition tables
+    docker exec apel-mysql mysql -u root -p$MYSQL_ROOT_PASSWORD apel_rest -e "`cat schemas/cloud-extra.sql`"
+    echo "Done"
+fi
 
 echo "Deploying APEL Server Container"
 
-# A (python) list of IAM service IDs allowed to submit GET requests.
-# This bash variable needs to be interpreted by python as a list of strings
-# i.e. [\'ac2f23e0-8103-4581-8014-e0e82c486e36\']
-# NEEDS POPULATING
-ALLOWED_FOR_GET=
-
-# An IAM ID corresponding to this instance, used to validate tokens.
-# NEEDS POPULATING
-SERVER_IAM_ID=
-
-# An IAM secret corresponding to this instance, used to validate tokens.
-# NEEDS POPULATING
-SERVER_IAM_SECRET=
-
-# The Django server requires its own "secret".
-# NEDDS POPULATING
-DJANGO_SECRET_KEY=
-
 docker run -d --link apel-mysql:mysql -p 80:80 -p 443:443 -e "MYSQL_PASSWORD=$MYSQL_PASSWORD" -e "ALLOWED_FOR_GET=$ALLOWED_FOR_GET" -e "SERVER_IAM_ID=$SERVER_IAM_ID" -e "SERVER_IAM_SECRET=$SERVER_IAM_SECRET" -e "DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY" $IMAGE_NAME
+
 
 # this allows the APEL REST interface to configure
 sleep 60

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eu
+
 # This script corresponds to the following  version
 VERSION="1.1.0-1"
 
@@ -19,6 +21,9 @@ if [ $# -ne 1 ] && [ $# -ne 3 ]
 then
     usage
 fi
+
+# Set defaults for options
+PULL="y"
 
 # Process options
 while getopts "hp:" OPT; do
@@ -41,12 +46,6 @@ while getopts "hp:" OPT; do
     esac
 done
 
-# Set defaults
-if [ -z $PULL]
-then
-    PULL="y"
-fi
-
 shift "$((OPTIND-1))" # Shift off the options and optional.
 
 # Set arguements
@@ -56,8 +55,8 @@ then
 fi
 
 IMAGE_NAME=$1
-echo "This script will deploy the containers for INDIGO-DataCloud Accounting, using $IMAGE_NAME."
-echo "Deploying $IMAGE_NAME with run_container.sh ($VERSION)."
+echo "This script will deploy the containers for INDIGO-DataCloud Accounting, using $IMAGE_NAME"
+echo "Deploying $IMAGE_NAME with run_container.sh ($VERSION)"
 
 # If -p y, or if -p was ommited
 if [ "$PULL" == "y" ]
@@ -68,7 +67,7 @@ else
     echo "Using local image: $IMAGE_NAME"
 fi
 
-echo "Deploying Database"
+echo "Deploying MySQL Container"
 
 # The database root password.
 # NEEDS POPULATING
@@ -99,7 +98,7 @@ docker exec apel-mysql mysql -u root -p$MYSQL_ROOT_PASSWORD apel_rest -e "`cat s
 
 echo "Done"
 
-echo "Deploying APEL Server"
+echo "Deploying APEL Server Container"
 
 # A (python) list of IAM service IDs allowed to submit GET requests.
 # This bash variable needs to be interpreted by python as a list of strings

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -95,7 +95,7 @@ then
 fi
 
 IMAGE_NAME=$1
-echo "This script will deploy the containers for INDIGO-DataCloud Accounting, using $IMAGE_NAME"
+echo "This script will deploy the containers for INDIGO-DataCloud Accounting"
 echo "Deploying $IMAGE_NAME with run_container.sh ($VERSION)"
 
 # If -p y, or if -p was ommited

--- a/docker/run_container.sh
+++ b/docker/run_container.sh
@@ -1,15 +1,70 @@
 #!/bin/bash
-echo "This script will deploy the containers for INDIGO-DataCloud Accounting."
+# This script corresponds to the following  version
+VERSION="1.1.0-1"
 
-if [ $# -ne 1 ]
+function usage {
+    echo "Version: $VERSION"
+    echo "USAGE:"
+    echo "./run_container.sh [ -p (y)|n ] IMAGE_NAME"
+    echo ""
+    echo "    -p y: the script will pull the image from a registry."
+    echo "       n: the script will omit the docker pull command,"
+    echo "          used to run an instance of a local image."
+    echo "    -h:   Displays the message."
+    exit
+}
+
+# Check arguement/option number is 1 or 3
+if [ $# -ne 1 ] && [ $# -ne 3 ]
 then
-    echo "ERROR: Must supply APEL REST Image name as first arguement."
-    exit -1
+    usage
 fi
 
-apel_rest_image=$1
+# Process options
+while getopts "hp:" OPT; do
+    case $OPT in
+       h) # Display the usage message
+           usage
+       ;;
+       p) # Pull the docker image or use locally
+           if [ "$OPTARG" == "y" ] || [ "$OPTARG" == "n" ]
+           then
+               PULL=$OPTARG
+           else
+               echo "Invalid -p arguement: $OPTARG"
+               usage
+           fi
+       ;;
+       ?)
+           usage
+       ;;
+    esac
+done
 
-docker pull $apel_rest_image
+# Set defaults
+if [ -z $PULL]
+then
+    PULL="y"
+fi
+
+shift "$((OPTIND-1))" # Shift off the options and optional.
+
+# Set arguements
+IMAGE_NAME=$1
+if [ -z $IMAGE_NAME ]
+then
+    echo "No image provided."
+    usage
+fi
+
+echo "This script will deploy the containers for INDIGO-DataCloud Accounting, using $IMAGE_NAME."
+echo "Deploying $IMAGE_NAME with run_container.sh ($VERSION)."
+
+# If -p y, or if -p was ommited
+if [ "$PULL" == "y" ]
+then
+    docker pull $apel_rest_image
+fi
 
 echo "Configuring Database"
 


### PR DESCRIPTION
Adds options to run_container.sh
* re-deploy server image only (easier to keep test data in local testing) 
* deploy locally built images without trying to pull from dockerhub (better for local testing)

These changes don't change the previous behaviour, just add new options