### PR TITLE
Add more test cases for GET requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache: pip
 # Commands that prepare things for the test
 before_script:
   # create an empty mysql database
-  - mysql -u root -e "create database apel_rest"
+  - mysql -u root -e "create database apel_test"
   - mysql -u root apel_rest < schemas/cloud.sql
   - export PYTHONPATH=$PYTHONPATH:`pwd -P`
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache: pip
 # Commands that prepare things for the test
 before_script:
   # create an empty mysql database
-  - mysql -u root -e "create database apel_test"
+  - mysql -u root -e "create database apel_rest"
   - mysql -u root apel_rest < schemas/cloud.sql
   - export PYTHONPATH=$PYTHONPATH:`pwd -P`
 

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -18,6 +18,26 @@ class CloudRecordSummaryTest(TestCase):
         """Prevent logging from appearing in test output."""
         logging.disable(logging.CRITICAL)
 
+    def test_cloud_record_summary_get_400(self):
+        """Test a GET request without the from field."""
+        # Mock the functionality of the IAM
+        CloudRecordSummaryView._token_to_id = Mock(return_value="TestService")
+
+        with self.settings(ALLOWED_FOR_GET='TestService',
+                           RETURN_HEADERS=["WallDuration",
+                                           "Day",
+                                           "Month",
+                                           "Year"]):
+            test_client = Client()
+            response = test_client.get(
+                                    '/api/v1/cloud/record/summary?'
+                                    'group=TestGroup',
+                                    HTTP_AUTHORIZATION="Bearer TestToken")
+
+        # Check the expected response code has been received.
+        self.assertEqual(response.status_code, 400)
+
+
     def test_cloud_record_summary_get_403(self):
         """Test a unauthorized GET request."""
         # Mock the functionality of the IAM

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -26,7 +26,9 @@ class CloudRecordSummaryTest(TestCase):
 
         IAM = Identity and Access Management
         """
+        # Mock the functionality of the IAM
         # Used in the underlying GET method
+        # Simulates a failure to translate a token to an ID
         CloudRecordSummaryView._token_to_id = Mock(return_value=None)
 
         with self.settings(ALLOWED_FOR_GET='TestService',
@@ -46,6 +48,8 @@ class CloudRecordSummaryTest(TestCase):
     def test_cloud_record_summary_get_400(self):
         """Test a GET request without the from field."""
         # Mock the functionality of the IAM
+        # Simulates the translation of a token to an ID
+        # Used in the underlying GET method
         CloudRecordSummaryView._token_to_id = Mock(return_value="TestService")
 
         with self.settings(ALLOWED_FOR_GET='TestService',
@@ -64,6 +68,8 @@ class CloudRecordSummaryTest(TestCase):
     def test_cloud_record_summary_get_403(self):
         """Test an unauthorized GET request."""
         # Mock the functionality of the IAM
+        # Simulates the translation of a token to an unauthorized ID
+        # Used in the underlying GET method
         CloudRecordSummaryView._token_to_id = Mock(return_value="FakeService")
 
         with self.settings(ALLOWED_FOR_GET='TestService',

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -31,10 +31,12 @@ class CloudRecordSummaryTest(TestCase):
 
     def test_cloud_record_summary_get_200(self):
         """Test a successful GET request."""
+        # Connect to database
+        database = self._connect_to_database()
         # Clean up any lingering example data.
-        self._clear_database()
+        self._clear_database(database)
         # Add example data
-        self._populate_database()
+        self._populate_database(database)
 
         # Mock the functionality of the IAM
         CloudRecordSummaryView._token_to_id = Mock(return_value="TestService")
@@ -72,7 +74,8 @@ class CloudRecordSummaryTest(TestCase):
         # Check the response received is as expected.
         self.assertEqual(response.content, expected_response)
         # Clean up after test.
-        self._clear_database()
+        self._clear_database(database)
+        database.close()
 
     def test_parse_query_parameters(self):
         """Test the parsing of query parameters."""
@@ -181,9 +184,9 @@ class CloudRecordSummaryTest(TestCase):
         """Delete any messages under QPATH and re-enable logging.INFO."""
         logging.disable(logging.NOTSET)
 
-    def _populate_database(self):
+    def _populate_database(self, database):
         """Populate the database with example summaries."""
-        (database, cursor) = self._connect_to_database()
+        cursor = database.cursor()
 
         # Insert example usage data
         cursor.execute('INSERT INTO CloudRecords '
@@ -217,9 +220,9 @@ class CloudRecordSummaryTest(TestCase):
         cursor.execute('CALL SummariseVMs();')
         database.commit()
 
-    def _clear_database(self):
+    def _clear_database(self, database):
         """Clear the database of example data."""
-        (database, cursor) = self._connect_to_database()
+        cursor = database.cursor()
 
         cursor.execute('DELETE FROM CloudRecords '
                        'WHERE VMUUID="TEST-VM";')
@@ -251,5 +254,4 @@ class CloudRecordSummaryTest(TestCase):
                              name='apel_rest'):
         """Connect to and return a cursor to the given database."""
         database = MySQLdb.connect(host, user, password, name)
-        cursor = database.cursor()
-        return (database, cursor)
+        return database

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -18,6 +18,27 @@ class CloudRecordSummaryTest(TestCase):
         """Prevent logging from appearing in test output."""
         logging.disable(logging.CRITICAL)
 
+    def test_cloud_record_summary_get_IAM_fail(self):
+        # Test what happens if we fail to contact the IAM,
+        # i.e, _token_to_id returns None
+        CloudRecordSummaryView._token_to_id = Mock(return_value=None)
+
+        with self.settings(ALLOWED_FOR_GET='TestService',
+                           RETURN_HEADERS=["WallDuration",
+                                           "Day",
+                                           "Month",
+                                           "Year"]):
+            test_client = Client()
+            response = test_client.get(
+                                    '/api/v1/cloud/record/summary?'
+                                    'group=TestGroup&'
+                                    'from=20000101&to=20191231',
+                                    HTTP_AUTHORIZATION="Bearer TestToken")
+
+        # Check the expected response code has been received.
+        self.assertEqual(response.status_code, 403)
+
+
     def test_cloud_record_summary_get_400(self):
         """Test a GET request without the from field."""
         # Mock the functionality of the IAM
@@ -36,7 +57,6 @@ class CloudRecordSummaryTest(TestCase):
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 400)
-
 
     def test_cloud_record_summary_get_403(self):
         """Test a unauthorized GET request."""

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -23,7 +23,10 @@ class CloudRecordSummaryTest(TestCase):
         Test what happens if we fail to contact the IAM.
 
         i.e, _token_to_id returns None
+
+        IAM = Identity and Access Management
         """
+        # Used in the underlying GET method
         CloudRecordSummaryView._token_to_id = Mock(return_value=None)
 
         with self.settings(ALLOWED_FOR_GET='TestService',
@@ -59,7 +62,7 @@ class CloudRecordSummaryTest(TestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_cloud_record_summary_get_403(self):
-        """Test a unauthorized GET request."""
+        """Test an unauthorized GET request."""
         # Mock the functionality of the IAM
         CloudRecordSummaryView._token_to_id = Mock(return_value="FakeService")
 
@@ -78,7 +81,7 @@ class CloudRecordSummaryTest(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_cloud_record_summary_get_401(self):
-        """Test a unauthenticated GET request."""
+        """Test an unauthenticated GET request."""
         test_client = Client()
         # Test without the HTTP_AUTHORIZATION header
         response = test_client.get('/api/v1/cloud/record/summary?'

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -36,7 +36,7 @@ class CloudRecordSummaryTest(TestCase):
                                     HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 401)
 
 
     def test_cloud_record_summary_get_400(self):
@@ -205,11 +205,10 @@ class CloudRecordSummaryTest(TestCase):
 
     def test_request_to_token_fail(self):
         """Test the response of a tokenless request."""
-        test_cloud_view = CloudRecordSummaryView()
-        factory = APIRequestFactory()
-        request = factory.get('/api/v1/cloud/record/summary?from=FromDate')
+        test_client = Client()
+        response = test_client.get('/api/v1/cloud/record/summary?from=FromDate')
 
-        self.assertRaises(KeyError, test_cloud_view._request_to_token, request)
+        self.assertEqual(response.status_code, 401)
 
     def test_is_client_authorized(self):
         """Test a example client is authorised."""

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -19,12 +19,23 @@ class CloudRecordSummaryTest(TestCase):
         logging.disable(logging.CRITICAL)
 
     def test_cloud_record_summary_get_401(self):
-        """Test a successful GET request."""
+        """Test a un authenticated GET request."""
         test_client = Client()
+        # Test without the HTTP_AUTHORIZATION header
         response = test_client.get(
                                 '/api/v1/cloud/record/summary?'
                                 'group=TestGroup&'
                                 'from=20000101&to=20191231')
+
+        # Check the expected response code has been received.
+        self.assertEqual(response.status_code, 401)
+
+        # Test with a malformed HTTP_AUTHORIZATION header
+        response = test_client.get(
+                                '/api/v1/cloud/record/summary?'
+                                'group=TestGroup&'
+                                'from=20000101&to=20191231',
+                                HTTP_AUTHORIZATION='TestToken')
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 401)

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -129,9 +129,6 @@ class CloudRecordSummaryTest(TestCase):
                                        'from=20000101&to=20191231',
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
-        # Check the expected response code has been received.
-        self.assertEqual(response.status_code, 200)
-
         expected_response = ('{'
                              '"count":2,'
                              '"next":null,'
@@ -147,11 +144,15 @@ class CloudRecordSummaryTest(TestCase):
                              '"Day":31,'
                              '"Month":7}]}')
 
-        # Check the response received is as expected.
-        self.assertEqual(response.content, expected_response)
-        # Clean up after test.
-        self._clear_database(database)
-        database.close()
+        try:
+            # Check the expected response code has been received.
+            self.assertEqual(response.status_code, 200)
+            # Check the response received is as expected.
+            self.assertEqual(response.content, expected_response)
+            # Clean up after test.
+        finally:
+            self._clear_database(database)
+            database.close()
 
     def test_parse_query_parameters(self):
         """Test the parsing of query parameters."""

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -19,8 +19,11 @@ class CloudRecordSummaryTest(TestCase):
         logging.disable(logging.CRITICAL)
 
     def test_cloud_record_summary_get_IAM_fail(self):
-        # Test what happens if we fail to contact the IAM,
-        # i.e, _token_to_id returns None
+        """
+        Test what happens if we fail to contact the IAM.
+
+        i.e, _token_to_id returns None
+        """
         CloudRecordSummaryView._token_to_id = Mock(return_value=None)
 
         with self.settings(ALLOWED_FOR_GET='TestService',
@@ -29,15 +32,13 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            response = test_client.get(
-                                    '/api/v1/cloud/record/summary?'
-                                    'group=TestGroup&'
-                                    'from=20000101&to=20191231',
-                                    HTTP_AUTHORIZATION="Bearer TestToken")
+            response = test_client.get('/api/v1/cloud/record/summary?'
+                                       'group=TestGroup&'
+                                       'from=20000101&to=20191231',
+                                       HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 401)
-
 
     def test_cloud_record_summary_get_400(self):
         """Test a GET request without the from field."""
@@ -50,10 +51,9 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            response = test_client.get(
-                                    '/api/v1/cloud/record/summary?'
-                                    'group=TestGroup',
-                                    HTTP_AUTHORIZATION="Bearer TestToken")
+            response = test_client.get('/api/v1/cloud/record/summary?'
+                                       'group=TestGroup',
+                                       HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 400)
@@ -69,11 +69,10 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            response = test_client.get(
-                                    '/api/v1/cloud/record/summary?'
-                                    'group=TestGroup&'
-                                    'from=20000101&to=20191231',
-                                    HTTP_AUTHORIZATION="Bearer TestToken")
+            response = test_client.get('/api/v1/cloud/record/summary?'
+                                       'group=TestGroup&'
+                                       'from=20000101&to=20191231',
+                                       HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 403)
@@ -82,20 +81,18 @@ class CloudRecordSummaryTest(TestCase):
         """Test a unauthenticated GET request."""
         test_client = Client()
         # Test without the HTTP_AUTHORIZATION header
-        response = test_client.get(
-                                '/api/v1/cloud/record/summary?'
-                                'group=TestGroup&'
-                                'from=20000101&to=20191231')
+        response = test_client.get('/api/v1/cloud/record/summary?'
+                                   'group=TestGroup&'
+                                   'from=20000101&to=20191231')
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 401)
 
         # Test with a malformed HTTP_AUTHORIZATION header
-        response = test_client.get(
-                                '/api/v1/cloud/record/summary?'
-                                'group=TestGroup&'
-                                'from=20000101&to=20191231',
-                                HTTP_AUTHORIZATION='TestToken')
+        response = test_client.get('/api/v1/cloud/record/summary?'
+                                   'group=TestGroup&'
+                                   'from=20000101&to=20191231',
+                                   HTTP_AUTHORIZATION='TestToken')
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 401)
@@ -118,11 +115,10 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            response = test_client.get(
-                                    '/api/v1/cloud/record/summary?'
-                                    'group=TestGroup&'
-                                    'from=20000101&to=20191231',
-                                    HTTP_AUTHORIZATION="Bearer TestToken")
+            response = test_client.get('/api/v1/cloud/record/summary?'
+                                       'group=TestGroup&'
+                                       'from=20000101&to=20191231',
+                                       HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 200)
@@ -206,7 +202,8 @@ class CloudRecordSummaryTest(TestCase):
     def test_request_to_token_fail(self):
         """Test the response of a tokenless request."""
         test_client = Client()
-        response = test_client.get('/api/v1/cloud/record/summary?from=FromDate')
+        get_url = '/api/v1/cloud/record/summary?from=FromDate'
+        response = test_client.get(get_url)
 
         self.assertEqual(response.status_code, 401)
 

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -18,8 +18,28 @@ class CloudRecordSummaryTest(TestCase):
         """Prevent logging from appearing in test output."""
         logging.disable(logging.CRITICAL)
 
+    def test_cloud_record_summary_get_403(self):
+        """Test a unauthorized GET request."""
+        # Mock the functionality of the IAM
+        CloudRecordSummaryView._token_to_id = Mock(return_value="FakeService")
+
+        with self.settings(ALLOWED_FOR_GET='TestService',
+                           RETURN_HEADERS=["WallDuration",
+                                           "Day",
+                                           "Month",
+                                           "Year"]):
+            test_client = Client()
+            response = test_client.get(
+                                    '/api/v1/cloud/record/summary?'
+                                    'group=TestGroup&'
+                                    'from=20000101&to=20191231',
+                                    HTTP_AUTHORIZATION="Bearer TestToken")
+
+        # Check the expected response code has been received.
+        self.assertEqual(response.status_code, 403)
+
     def test_cloud_record_summary_get_401(self):
-        """Test a un authenticated GET request."""
+        """Test a unauthenticated GET request."""
         test_client = Client()
         # Test without the HTTP_AUTHORIZATION header
         response = test_client.get(

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -264,4 +264,6 @@ class CloudRecordSummaryView(APIView):
         return client_id
 
     def _is_client_authorized(self, client_id):
+        if client_id == None:
+            return False
         return client_id in settings.ALLOWED_FOR_GET

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -238,6 +238,7 @@ class CloudRecordSummaryView(APIView):
         return token
 
     def _token_to_id(self, token):
+        logger = logging.getLogger(__name__)
         try:
             auth_request = urllib2.Request(
                            'https://iam-test.indigo-datacloud.eu/introspect',
@@ -257,7 +258,8 @@ class CloudRecordSummaryView(APIView):
                 urllib2.URLError,
                 httplib.HTTPException,
                 KeyError) as e:
-            raise e
+            logger.error(e)
+            return None
 
         return client_id
 

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -264,6 +264,6 @@ class CloudRecordSummaryView(APIView):
         return client_id
 
     def _is_client_authorized(self, client_id):
-        if client_id == None:
+        if client_id is None:
             return False
         return client_id in settings.ALLOWED_FOR_GET

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -253,7 +253,7 @@ class CloudRecordSummaryView(APIView):
 
     def _is_client_authorized(self, client_id):
         """
-        Return true iff client_id can access summaries.
+        Return true if and only if client_id can access summaries.
 
         i.e. client_id is not None and is in settings.ALLOWED_FOR_GET.
         """

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -232,10 +232,9 @@ class CloudRecordSummaryView(APIView):
             server_id = settings.SERVER_IAM_ID
             server_secret = settings.SERVER_IAM_SECRET
 
-            encode_string = ('%s:%s' % (server_id,
-                                        server_secret)).replace('\n', '')
+            encode_string = '%s:%s' % (server_id, server_secret)
 
-            base64string = base64.encodestring(encode_string)
+            base64string = base64.encodestring(encode_string).replace('\n', '')
 
             auth_request.add_header("Authorization", "Basic %s" % base64string)
             auth_result = urllib2.urlopen(auth_request)


### PR DESCRIPTION
Adds test cases for a GET requests, checking 200, 400, 401 and 403 responses.

- also moves some of the logging into helper functions
- CloudSummaryRecordView changes so that methods return values rather than raising exceptions to make testing easier (i.e. returning None from method is mockable more easily). The moving of the logging simplifies the top level method get()