### PR TITLE
Factor out the external call (to get the list of providers) to single method

### DIFF
--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -165,4 +165,4 @@ RETURN_HEADERS = ["VOGroup",
 # this doesnt do anything, probably because of using older Django
 URL_FORMAT_OVERRIDE = None
 
-PROVIDERS_URL="http://indigo.cloud.plgrid.pl/cmdb/service/list"
+PROVIDERS_URL = "http://indigo.cloud.plgrid.pl/cmdb/service/list"

--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -164,3 +164,5 @@ RETURN_HEADERS = ["VOGroup",
 # this should hide the GET?format button
 # this doesnt do anything, probably because of using older Django
 URL_FORMAT_OVERRIDE = None
+
+PROVIDERS_URL="http://indigo.cloud.plgrid.pl/cmdb/service/list"

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -6,6 +6,12 @@ import os
 import shutil
 
 from django.test import Client, TestCase
+from mock import Mock
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+from api.views.CloudRecordView import CloudRecordView
+
 
 QPATH_TEST = '/tmp/django-test/'
 
@@ -17,36 +23,48 @@ class CloudRecordTest(TestCase):
         """Disable logging.INFO from appearing in test output."""
         logging.disable(logging.INFO)
 
-#    def test_cloud_record_post(self):
-#        """Test a POST call for content equality and a 202 return code."""
-#        with self.settings(QPATH=QPATH_TEST):
-#            test_client = Client()
-#            example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=cloud.recas.ba.infn.it"
-#            response = test_client.post("/api/v1/cloud/record",
-#                                        MESSAGE,
-#                                        content_type="text/plain",
-#                                        HTTP_EMPA_ID="Test Process",
-#                                        SSL_CLIENT_S_DN=example_dn)
+    def test_cloud_record_post(self):
+        """Test a POST call for content equality and a 202 return code."""
+        with self.settings(QPATH=QPATH_TEST):
+            CloudRecordView._get_provider_list = Mock(return_value={
+                'total_rows':735,
+                'offset':695,
+                'rows':[
+                    {'id':'1',
+                     'key':['service'],
+                     'value':{
+                         'sitename':'TEST',
+                         'provider_id':'TEST',
+                         'hostname':'test.com',
+                         'type':'cloud'}}]})
 
-#            # check the expected response code has been received
-#            self.assertEqual(response.status_code, 202)
+            test_client = Client()
+            example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=test.com"
+            response = test_client.post("/api/v1/cloud/record",
+                                        MESSAGE,
+                                        content_type="text/plain",
+                                        HTTP_EMPA_ID="Test Process",
+                                        SSL_CLIENT_S_DN=example_dn)
 
-#            # get save messages under QPATH_TEST
-#            messages = self._saved_messages('%s*/*/*/body' % QPATH_TEST)
+            # check the expected response code has been received
+            self.assertEqual(response.status_code, 202)
 
-#            # check one and only one message body saved
-#            self.assertEqual(len(messages), 1)
+            # get save messages under QPATH_TEST
+            messages = self._saved_messages('%s*/*/*/body' % QPATH_TEST)
 
-#            # get message content
-#            # can unpack sequence because we have asserted length 1
-#            [message] = messages
-#            message_file = open(message)
-#            message_content = message_file.read()
-#            message_file.close()
+            # check one and only one message body saved
+            self.assertEqual(len(messages), 1)
 
-#            # check saved message content
-#            self.assertEqual(MESSAGE, message_content)
-#            self._delete_messages(QPATH_TEST)
+            # get message content
+            # can unpack sequence because we have asserted length 1
+            [message] = messages
+            message_file = open(message)
+            message_content = message_file.read()
+            message_file.close()
+
+            # check saved message content
+            self.assertEqual(MESSAGE, message_content)
+            self._delete_messages(QPATH_TEST)
 
     # def test_filter_cursor(self):
         # pass

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -20,11 +20,11 @@ class CloudRecordTest(TestCase):
     """Tests POST requests to the Cloud Record endpoint."""
 
     def setUp(self):
-        """Disable logging from appearing in test output."""
+        """Prevent logging from appearing in test output."""
         logging.disable(logging.CRITICAL)
 
     def test_cloud_record_post_403(self):
-        """Test a POST request from a unregistered provider."""
+        """Test unknown provider POST request returns a 403 code."""
         with self.settings(QPATH=QPATH_TEST):
             # Mock the functionality of the provider url
             # Used in the underlying POST handling method
@@ -44,23 +44,21 @@ class CloudRecordTest(TestCase):
             self.assertEqual(response.status_code, 403)
 
     def test_cloud_record_post_401(self):
-        """Test a certificate-less POST request."""
+        """Test certificate-less POST request returns a 401 code."""
         with self.settings(QPATH=QPATH_TEST):
             test_client = Client()
-            response = test_client.post(
-                                    "/api/v1/cloud/record",
-                                    MESSAGE,
-                                    content_type="text/plain",
-                                    HTTP_EMPA_ID="Test Process")
-                                    # No DN to simulate
-                                    # a certificate-less request
+            # No SSL_CLIENT_S_DN in POST to
+            # simulate a certificate-less request
+            response = test_client.post("/api/v1/cloud/record",
+                                        MESSAGE,
+                                        content_type="text/plain",
+                                        HTTP_EMPA_ID="Test Process")
 
             # check the expected response code has been received
             self.assertEqual(response.status_code, 401)
 
-
     def test_cloud_record_post_202(self):
-        """Test a POST call for content equality and a 202 return code."""
+        """Test POST request for content equality and a 202 return code."""
         with self.settings(QPATH=QPATH_TEST):
             # Mock the functionality of the provider url
             # Used in the underlying POST handling method
@@ -111,16 +109,16 @@ class CloudRecordTest(TestCase):
         """Return a list of messages under message_path."""
         return glob.glob(message_path)
 
-PROVIDERS = {'total_rows':735,
-             'offset':695,
-             'rows':[
-                 {'id':'1',
-                  'key':['service'],
+PROVIDERS = {'total_rows': 735,
+             'offset': 695,
+             'rows': [
+                 {'id': '1',
+                  'key': ['service'],
                   'value':{
-                      'sitename':'TEST',
-                      'provider_id':'TEST',
-                      'hostname':'allowed_host.test',
-                      'type':'cloud'}}]}
+                      'sitename': 'TEST',
+                      'provider_id': 'TEST',
+                      'hostname': 'allowed_host.test',
+                      'type': 'cloud'}}]}
 
 MESSAGE = """APEL-cloud-message: v0.2
 VMUUID: TestVM1 2013-02-25 17:37:27+00:00

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -43,37 +43,34 @@ class CloudRecordTest(TestCase):
 
     def test_cloud_record_post_403(self):
         """Test unknown provider POST request returns a 403 code."""
-        with self.settings(QPATH=QPATH_TEST):
-            # Mock the functionality of the provider list
-            # Used in the underlying POST handling method
-            # Allows only allowed_host.test to POST
-            CloudRecordView._get_provider_list = Mock(return_value=PROVIDERS)
+        # Mock the functionality of the provider list
+        # Used in the underlying POST handling method
+        # Allows only allowed_host.test to POST
+        CloudRecordView._get_provider_list = Mock(return_value=PROVIDERS)
 
-            test_client = Client()
-            example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=prohibited_host.test"
-            response = test_client.post(
-                                    "/api/v1/cloud/record",
+        test_client = Client()
+        example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=prohibited_host.test"
+        response = test_client.post("/api/v1/cloud/record",
                                     MESSAGE,
                                     content_type="text/plain",
                                     HTTP_EMPA_ID="Test Process",
                                     SSL_CLIENT_S_DN=example_dn)
 
-            # check the expected response code has been received
-            self.assertEqual(response.status_code, 403)
+        # check the expected response code has been received
+        self.assertEqual(response.status_code, 403)
 
     def test_cloud_record_post_401(self):
         """Test certificate-less POST request returns a 401 code."""
-        with self.settings(QPATH=QPATH_TEST):
-            test_client = Client()
-            # No SSL_CLIENT_S_DN in POST to
-            # simulate a certificate-less request
-            response = test_client.post("/api/v1/cloud/record",
-                                        MESSAGE,
-                                        content_type="text/plain",
-                                        HTTP_EMPA_ID="Test Process")
+        test_client = Client()
+        # No SSL_CLIENT_S_DN in POST to
+        # simulate a certificate-less request
+        response = test_client.post("/api/v1/cloud/record",
+                                    MESSAGE,
+                                    content_type="text/plain",
+                                    HTTP_EMPA_ID="Test Process")
 
-            # check the expected response code has been received
-            self.assertEqual(response.status_code, 401)
+        # check the expected response code has been received
+        self.assertEqual(response.status_code, 401)
 
     def test_cloud_record_post_202(self):
         """Test POST request for content equality and a 202 return code."""

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -23,10 +23,28 @@ class CloudRecordTest(TestCase):
         """Prevent logging from appearing in test output."""
         logging.disable(logging.CRITICAL)
 
+    def test_cloud_record_post_provider_fail(self):
+        """Test what happens if we fail to retrieve the providers."""
+        # Mock the functionality of the provider list
+        # Used in the underlying POST handling method
+        # Shouldn't allow any POSTs,
+        # i.e. we have failed to retrieve the providers list
+        CloudRecordView._get_provider_list = Mock(return_value={})
+
+        test_client = Client()
+        example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=allowed_host.test"
+        response = test_client.post("/api/v1/cloud/record",
+                                    MESSAGE,
+                                    content_type="text/plain",
+                                    HTTP_EMPA_ID="Test Process",
+                                    SSL_CLIENT_S_DN=example_dn)
+
+        self.assertEqual(response.status_code, 403)
+
     def test_cloud_record_post_403(self):
         """Test unknown provider POST request returns a 403 code."""
         with self.settings(QPATH=QPATH_TEST):
-            # Mock the functionality of the provider url
+            # Mock the functionality of the provider list
             # Used in the underlying POST handling method
             # Allows only allowed_host.test to POST
             CloudRecordView._get_provider_list = Mock(return_value=PROVIDERS)
@@ -60,7 +78,7 @@ class CloudRecordTest(TestCase):
     def test_cloud_record_post_202(self):
         """Test POST request for content equality and a 202 return code."""
         with self.settings(QPATH=QPATH_TEST):
-            # Mock the functionality of the provider url
+            # Mock the functionality of the provider list
             # Used in the underlying POST handling method
             # Allows only allowed_host.test to POST
             CloudRecordView._get_provider_list = Mock(return_value=PROVIDERS)

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -93,9 +93,6 @@ class CloudRecordTest(TestCase):
             self.assertEqual(MESSAGE, message_content)
             self._delete_messages(QPATH_TEST)
 
-    # def test_filter_cursor(self):
-        # pass
-
     def tearDown(self):
         """Delete any messages under QPATH and re-enable logging.INFO."""
         logging.disable(logging.NOTSET)

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -115,12 +115,12 @@ class CloudRecordView(APIView):
 
         providers = self._get_provider_list()
 
-        for site_num, _ in enumerate(providers['rows']):
-            try:
+        try:
+            for site_num, _ in enumerate(providers['rows']):
                 if signer in providers['rows'][site_num]['value']['hostname']:
                     return True
-            except KeyError:
-                pass
+        except KeyError:
+            pass
 
         # If we have not returned while in for loop
         # then site must be invalid

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -93,7 +93,7 @@ class CloudRecordView(APIView):
 ###############################################################################
 
     def _get_provider_list(self):
-        """Return a list of Indigo Providers."""
+        """Return a list of Resource Providers."""
         logger = logging.getLogger(__name__)
 
         try:
@@ -103,11 +103,11 @@ class CloudRecordView(APIView):
 
         except (ValueError, urllib2.HTTPError) as error:
             logger.error("List of providers could not be retrieved.")
-            logger.error("%s: %s", type(error), str(error))
+            logger.error("%s: %s", type(error), error)
             return {}
 
     def _signer_is_valid(self, signer_dn):
-        """Return True is signer's host is listed as a Indigo Provider."""
+        """Return True if signer's host is listed as a Resource Provider."""
         logger = logging.getLogger(__name__)
 
         # Get the hostname from the DN
@@ -121,7 +121,7 @@ class CloudRecordView(APIView):
                 if signer in providers['rows'][site_num]['value']['hostname']:
                     return True
         except KeyError:
-            pass
+            logging.error('Could not parse list of providers.')
 
         # If we have not returned while in for loop
         # then site must be invalid

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -96,13 +96,14 @@ class CloudRecordView(APIView):
         """Return a list of Indigo Providers."""
         logger = logging.getLogger(__name__)
 
-        provider_list_request = urllib2.Request(settings.PROVIDERS_URL)
-        provider_list_response = urllib2.urlopen(provider_list_request)
-
         try:
+            provider_list_request = urllib2.Request(settings.PROVIDERS_URL)
+            provider_list_response = urllib2.urlopen(provider_list_request)
             return json.loads(provider_list_response.read())
-        except ValueError:
+
+        except (ValueError, urllib2.HTTPError) as error:
             logger.error("List of providers could not be retrieved.")
+            logger.error("%s: %s", type(error), str(error))
             return {}
 
     def _signer_is_valid(self, signer_dn):

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -92,6 +92,11 @@ class CloudRecordView(APIView):
 #                                                                             #
 ###############################################################################
 
+    def _get_signer_list(self):
+        """Return a list of Indigo Providers."""
+        site_list_request = urllib2.Request(settings.PROVIDERS_URL)
+        return urllib2.urlopen(site_list_request)
+
     def _signer_is_valid(self, signer_dn):
         """Return True is signer's host is listed as a Indigo Provider."""
         logger = logging.getLogger(__name__)
@@ -100,9 +105,7 @@ class CloudRecordView(APIView):
         signer_split = signer_dn.split("=")
         signer = signer_split[len(signer_split)-1]
 
-        site_list = urllib2.Request(
-            'http://indigo.cloud.plgrid.pl/cmdb/service/list')
-        site_list = urllib2.urlopen(site_list)
+        site_list = self._get_signer_list()
 
         try:
             site_json = json.loads(site_list.read())


### PR DESCRIPTION
Changes to api/views/CloudRecordView.py 
* Factor out the external call (to get the list of providers) to single method
* Move `enumerate(site_json['rows']` into `try...except` becaue if external call fails it throws an exception

Also adds new tests for
* Successful POST
* Unauthorized POST
* Unauthenticated POST
* External call fails during POST 