### PR TITLE
Removal of the method level getLogger() calls

### DIFF
--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -93,38 +93,27 @@ LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
-        'verbose': {
-            'format': ("[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s]: "
-                       " %(message)s"),
-            'datefmt': "%d/%b/%Y %H:%M:%S"
-        },
         'simple': {
             'format': '%(levelname)s: %(message)s'
         },
     },
     'handlers': {
-        # 'file': {
-        #     'class': 'logging.FileHandler',
-        #     'filename': './apel_rest.log',
-        #     'formatter': 'verbose'
-        # },
         'console': {
             'class': 'logging.StreamHandler',
             'formatter': 'simple'
         },
     },
     'loggers': {
-        'django': {
+        'django': {  # This logger is needed to catch django errors
             'handlers': ['console'],
             'propagate': True,
             'level': 'INFO',
-        },
-        'api': {
-            'handlers': ['console'],
-            'level': 'INFO',
-            # 'level': 'DEBUG',
-        },
-    }
+         },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
 }
 
 # XML stuff

--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -93,6 +93,9 @@ LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
+        'verbose': {
+            'format': '%(levelname)s [%(name)s:%(lineno)s]: %(message)s'
+        },
         'simple': {
             'format': '%(levelname)s: %(message)s'
         },
@@ -108,11 +111,12 @@ LOGGING = {
             'handlers': ['console'],
             'propagate': True,
             'level': 'INFO',
-         },
-    },
-    'root': {
-        'handlers': ['console'],
-        'level': 'INFO',
+        },
+        'api': {
+            'handlers': ['console'],
+            'propagate': False,
+            'level': 'INFO',
+        },
     },
 }
 

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -28,24 +28,22 @@ class CloudRecordView(APIView):
 
         Will save Cloud Accounting Records for later loading.
         """
-        logger = logging.getLogger(__name__)
-
         try:
             empaid = request.META['HTTP_EMPA_ID']
         except KeyError:
             empaid = 'noid'
 
-        logger.info("Received message. ID = %s", empaid)
+        logging.info("Received message. ID = %s", empaid)
 
         try:
             signer = request.META['SSL_CLIENT_S_DN']
         except KeyError:
-            logger.error("No DN supplied in header")
+            logging.error("No DN supplied in header")
             return Response(status=401)
 
         # authorise DNs here
         if not self._signer_is_valid(signer):
-            logger.error("%s not a valid provider", signer)
+            logging.error("%s not a valid provider", signer)
             return Response(status=403)
 
         if "_content" in request.POST.dict():
@@ -58,10 +56,10 @@ class CloudRecordView(APIView):
             # hence use request.body as message
             body = request.body
 
-        logger.debug("Message body received: %s", body)
+        logging.debug("Message body received: %s", body)
 
         for header in request.META:
-            logger.debug("%s: %s", header, request.META[header])
+            logging.debug("%s: %s", header, request.META[header])
 
         # taken from ssm2
         QSCHEMA = {'body': 'string',
@@ -76,12 +74,12 @@ class CloudRecordView(APIView):
                             'signer': signer,
                             'empaid': empaid})
         except QueueError as err:
-            logger.error("Could not save %s/%s: %s", inqpath, name, err)
+            logging.error("Could not save %s/%s: %s", inqpath, name, err)
 
             response = "Data could not be saved to disk, please try again."
             return Response(response, status=500)
 
-        logger.info("Message saved to in queue as %s/%s", inqpath, name)
+        logging.info("Message saved to in queue as %s/%s", inqpath, name)
 
         response = "Data successfully saved for future loading."
         return Response(response, status=202)
@@ -94,22 +92,18 @@ class CloudRecordView(APIView):
 
     def _get_provider_list(self):
         """Return a list of Resource Providers."""
-        logger = logging.getLogger(__name__)
-
         try:
             provider_list_request = urllib2.Request(settings.PROVIDERS_URL)
             provider_list_response = urllib2.urlopen(provider_list_request)
             return json.loads(provider_list_response.read())
 
         except (ValueError, urllib2.HTTPError) as error:
-            logger.error("List of providers could not be retrieved.")
-            logger.error("%s: %s", type(error), error)
+            logging.error("List of providers could not be retrieved.")
+            logging.error("%s: %s", type(error), error)
             return {}
 
     def _signer_is_valid(self, signer_dn):
         """Return True if signer's host is listed as a Resource Provider."""
-        logger = logging.getLogger(__name__)
-
         # Get the hostname from the DN
         signer_split = signer_dn.split("=")
         signer = signer_split[len(signer_split)-1]
@@ -125,5 +119,5 @@ class CloudRecordView(APIView):
 
         # If we have not returned while in for loop
         # then site must be invalid
-        logger.info('Site is not found on list of providers')
+        logging.info('Site is not found on list of providers')
         return False


### PR DESCRIPTION
Removes the method level getLogger() calls, uses class level logging instead.
- also removes timestamp from the verbose format as it appear twice in log output.