### PR TITLE
Split _signer _is_valid try..catch section into two sections

### DIFF
--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -127,6 +127,12 @@ PROVIDERS = {'total_rows': 735,
                  {'id': '1',
                   'key': ['service'],
                   'value':{
+                      'sitename': 'TEST2',
+                      'provider_id': 'TEST2',
+                      'type': 'cloud'}},
+                 {'id': '2',
+                  'key': ['service'],
+                  'value':{
                       'sitename': 'TEST',
                       'provider_id': 'TEST',
                       'hostname': 'allowed_host.test',

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -115,11 +115,11 @@ class CloudRecordView(APIView):
 
         providers = self._get_provider_list()
 
-        # If this fails, it is likely the provider
-        # list is not of expected format.
         try:
+            # Extract the site JSON objects from the returned JSON
             enumerated_providers = enumerate(providers['rows'])
         except KeyError:
+            # The returned provider JSON is not of expected format.
             self.logger.error('Could not parse provider JSON.')
             return False
 
@@ -128,12 +128,12 @@ class CloudRecordView(APIView):
                 if signer in site_json['value']['hostname']:
                     return True
             except KeyError:
-                # If this warning appears, a entry on the
-                # provider list doesn't have a hostname key.
-                # Will continue looping through provider list as
-                # a single hostless entry might not be an problem.
+                # A KeyError is thrown if a hostname is not defined.
+                # Log that a single site could not be parsed
                 logging.warning('Could not parse site JSON.')
                 logging.debug(site_json)
+                # Continue looping through provider list, looking
+                # for a match in the remaining site JSON
 
         # If we have not returned while in the above
         # for loop then site must be invalid


### PR DESCRIPTION
- An 'enumerate' section and a 'hostname extraction' section
- Because they should be handled separately
- If JSON is of the wrong format it now returns False
- If a site, in the correctly formatted JSON, doesn't define a hostname, it will now continue extracting hostnames.

Extended Explanation:
Change to the method that authorizes a provider to POST based on DN/hostname.

This method has requires an external api call to return the list of valid providers. If the returned JSON is not in the expected format this method could throw a KeyError in two different ways. 

First, if the returned JSON is not of the form `{"total_rows":744,"offset":703,"rows":[...list of JSON objects representing sites...]}`, then `enumerate(providers['rows'])` could throw a KeyError. In this case, the method should return False immediately - i.e. do not authorize the POST request

Secondly, `site_json['value']['hostname']` could fail as some sites are represented without the hostname key. In this case the method should continue looping through the list of sites, and authorize it if a match is found later in the list. 

Previously, both ways were handled in the same 'try..except' block, meaning a single site without a hostname could cause a POST to be blocked.