### PR TITLE
Removes hardcoded urls from test cases

### DIFF
--- a/apel_rest/urls.py
+++ b/apel_rest/urls.py
@@ -13,8 +13,12 @@ urlpatterns = patterns('',
                        # url(r'^blog/', include('blog.urls')),
 
                        url(r'^admin/',
-                           include(admin.site.urls)),
+                           include(admin.site.urls,)),
+
                        url(r'^api/v1/cloud/record$',
-                           CloudRecordView.as_view()),
+                           CloudRecordView.as_view(),
+                           name='CloudRecordView'),
+
                        url(r'^api/v1/cloud/record/summary$',
-                           CloudRecordSummaryView.as_view()))
+                           CloudRecordSummaryView.as_view(),
+                           name='CloudRecordSummaryView'))

--- a/apel_rest/urls.py
+++ b/apel_rest/urls.py
@@ -13,7 +13,7 @@ urlpatterns = patterns('',
                        # url(r'^blog/', include('blog.urls')),
 
                        url(r'^admin/',
-                           include(admin.site.urls,)),
+                           include(admin.site.urls)),
 
                        url(r'^api/v1/cloud/record$',
                            CloudRecordView.as_view(),

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -5,13 +5,13 @@ import logging
 import os
 import shutil
 
+from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 from mock import Mock
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from api.views.CloudRecordView import CloudRecordView
-
 
 QPATH_TEST = '/tmp/django-test/'
 
@@ -33,7 +33,7 @@ class CloudRecordTest(TestCase):
 
         test_client = Client()
         example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=allowed_host.test"
-        response = test_client.post("/api/v1/cloud/record",
+        response = test_client.post(reverse('CloudRecordView'),
                                     MESSAGE,
                                     content_type="text/plain",
                                     HTTP_EMPA_ID="Test Process",
@@ -50,7 +50,7 @@ class CloudRecordTest(TestCase):
 
         test_client = Client()
         example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=prohibited_host.test"
-        response = test_client.post("/api/v1/cloud/record",
+        response = test_client.post(reverse('CloudRecordView'),
                                     MESSAGE,
                                     content_type="text/plain",
                                     HTTP_EMPA_ID="Test Process",
@@ -64,7 +64,7 @@ class CloudRecordTest(TestCase):
         test_client = Client()
         # No SSL_CLIENT_S_DN in POST to
         # simulate a certificate-less request
-        response = test_client.post("/api/v1/cloud/record",
+        response = test_client.post(reverse('CloudRecordView'),
                                     MESSAGE,
                                     content_type="text/plain",
                                     HTTP_EMPA_ID="Test Process")
@@ -82,7 +82,7 @@ class CloudRecordTest(TestCase):
 
             test_client = Client()
             example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=allowed_host.test"
-            response = test_client.post("/api/v1/cloud/record",
+            response = test_client.post(reverse('CloudRecordView'),
                                         MESSAGE,
                                         content_type="text/plain",
                                         HTTP_EMPA_ID="Test Process",

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -50,7 +50,9 @@ class CloudRecordTest(TestCase):
 
         test_client = Client()
         example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=prohibited_host.test"
-        response = test_client.post(reverse('CloudRecordView'),
+        url = reverse('CloudRecordView')
+
+        response = test_client.post(url,
                                     MESSAGE,
                                     content_type="text/plain",
                                     HTTP_EMPA_ID="Test Process",
@@ -64,7 +66,9 @@ class CloudRecordTest(TestCase):
         test_client = Client()
         # No SSL_CLIENT_S_DN in POST to
         # simulate a certificate-less request
-        response = test_client.post(reverse('CloudRecordView'),
+        url = reverse('CloudRecordView')     
+
+        response = test_client.post(url,
                                     MESSAGE,
                                     content_type="text/plain",
                                     HTTP_EMPA_ID="Test Process")
@@ -82,7 +86,9 @@ class CloudRecordTest(TestCase):
 
             test_client = Client()
             example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=allowed_host.test"
-            response = test_client.post(reverse('CloudRecordView'),
+            url = reverse('CloudRecordView')
+
+            response = test_client.post(url,
                                         MESSAGE,
                                         content_type="text/plain",
                                         HTTP_EMPA_ID="Test Process",

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -4,6 +4,7 @@ import logging
 import MySQLdb
 
 from api.views.CloudRecordSummaryView import CloudRecordSummaryView
+from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 from mock import Mock
 from rest_framework.test import APIRequestFactory
@@ -36,10 +37,14 @@ class CloudRecordSummaryTest(TestCase):
                                            "Day",
                                            "Month",
                                            "Year"]):
+
             test_client = Client()
-            response = test_client.get('/api/v1/cloud/record/summary?'
-                                       'group=TestGroup&'
-                                       'from=20000101&to=20191231',
+            get_url = ''.join((reverse('CloudRecordSummaryView'),
+                               '?group=TestGroup',
+                               '&from=20000101',
+                               '&to=20191231'))
+
+            response = test_client.get(get_url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
@@ -58,8 +63,9 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            response = test_client.get('/api/v1/cloud/record/summary?'
-                                       'group=TestGroup',
+            get_url = ''.join((reverse('CloudRecordSummaryView'),
+                               '?group=TestGroup'))
+            response = test_client.get(get_url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
@@ -78,9 +84,12 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            response = test_client.get('/api/v1/cloud/record/summary?'
-                                       'group=TestGroup&'
-                                       'from=20000101&to=20191231',
+            get_url = ''.join((reverse('CloudRecordSummaryView'),
+                               '?group=TestGroup',
+                               '&from=20000101',
+                               '&to=20191231'))
+
+            response = test_client.get(get_url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
@@ -90,17 +99,21 @@ class CloudRecordSummaryTest(TestCase):
         """Test an unauthenticated GET request."""
         test_client = Client()
         # Test without the HTTP_AUTHORIZATION header
-        response = test_client.get('/api/v1/cloud/record/summary?'
-                                   'group=TestGroup&'
-                                   'from=20000101&to=20191231')
+        get_url = ''.join((reverse('CloudRecordSummaryView'),
+                           '?group=TestGroup',
+                           '&from=20000101',
+                           '&to=20191231'))
+
+        response = test_client.get(get_url)
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 401)
 
         # Test with a malformed HTTP_AUTHORIZATION header
-        response = test_client.get('/api/v1/cloud/record/summary?'
-                                   'group=TestGroup&'
-                                   'from=20000101&to=20191231',
+        response = test_client.get(''.join((reverse('CloudRecordSummaryView'),
+                                            '?group=TestGroup',
+                                            '&from=20000101',
+                                            '&to=20191231')),
                                    HTTP_AUTHORIZATION='TestToken')
 
         # Check the expected response code has been received.
@@ -124,9 +137,12 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            response = test_client.get('/api/v1/cloud/record/summary?'
-                                       'group=TestGroup&'
-                                       'from=20000101&to=20191231',
+            get_url = ''.join((reverse('CloudRecordSummaryView'),
+                               '?group=TestGroup',
+                               '&from=20000101',
+                               '&to=20191231'))
+
+            response = test_client.get(get_url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
         expected_response = ('{'
@@ -159,17 +175,19 @@ class CloudRecordSummaryTest(TestCase):
         # test a get with group, summary, start and end
         test_cloud_view = CloudRecordSummaryView()
         factory = APIRequestFactory()
-        request = factory.get(('/api/v1/cloud/record/summary?'
-                               'group=Group1&'
-                               'service=Service1&'
-                               'from=FromDate&to=ToDate'), {})
+        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
+                                       '?group=Group1',
+                                       '&service=Service1',
+                                       '&from=FromDate',
+                                       '&to=ToDate')), {})
 
         parsed_responses = test_cloud_view._parse_query_parameters(request)
         self.assertEqual(parsed_responses,
                          ("Group1", "Service1", "FromDate", "ToDate"))
 
         # test a get with just an end date
-        request = factory.get('/api/v1/cloud/record/summary?to=ToDate', {})
+        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
+                              '?to=ToDate')), {})
         parsed_responses = test_cloud_view._parse_query_parameters(request)
         self.assertEqual(parsed_responses,
                          (None, None, None, "ToDate"))
@@ -190,12 +208,14 @@ class CloudRecordSummaryTest(TestCase):
         factory = APIRequestFactory()
 
         # test when page number is not a number
-        request = factory.get('/api/v1/cloud/record/summary?page=a')
+        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
+                              '?page=a')))
         content = test_cloud_view._paginate_result(request, [])
         self.assertEqual(content, expected_content)
 
         # test when page number is out of bounds
-        request = factory.get('/api/v1/cloud/record/summary?page=9999')
+        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
+                              '?page=9999')))
         content = test_cloud_view._paginate_result(request, [])
         self.assertEqual(content, expected_content)
 
@@ -203,7 +223,8 @@ class CloudRecordSummaryTest(TestCase):
         """Test a token can be extracted from request."""
         test_cloud_view = CloudRecordSummaryView()
         factory = APIRequestFactory()
-        request = factory.get('/api/v1/cloud/record/summary?from=FromDate',
+        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
+                              '?from=FromDate')),
                               HTTP_AUTHORIZATION='Bearer ThisIsAToken')
 
         token = test_cloud_view._request_to_token(request)
@@ -212,8 +233,8 @@ class CloudRecordSummaryTest(TestCase):
     def test_request_to_token_fail(self):
         """Test the response of a tokenless request."""
         test_client = Client()
-        get_url = '/api/v1/cloud/record/summary?from=FromDate'
-        response = test_client.get(get_url)
+        response = test_client.get(''.join((reverse('CloudRecordSummaryView'),
+                                   '?from=FromDate')))
 
         self.assertEqual(response.status_code, 401)
 

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -64,7 +64,8 @@ class CloudRecordSummaryTest(TestCase):
                                            "Year"]):
             test_client = Client()
             url = ''.join((reverse('CloudRecordSummaryView'),
-                          '?group=TestGroup'))
+                           '?group=TestGroup'))
+
             response = test_client.get(url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
@@ -110,10 +111,12 @@ class CloudRecordSummaryTest(TestCase):
         self.assertEqual(response.status_code, 401)
 
         # Test with a malformed HTTP_AUTHORIZATION header
-        response = test_client.get(''.join((reverse('CloudRecordSummaryView'),
-                                            '?group=TestGroup',
-                                            '&from=20000101',
-                                            '&to=20191231')),
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?group=TestGroup',
+                       '&from=20000101',
+                       '&to=20191231'))
+
+        response = test_client.get(url,
                                    HTTP_AUTHORIZATION='TestToken')
 
         # Check the expected response code has been received.
@@ -175,19 +178,23 @@ class CloudRecordSummaryTest(TestCase):
         # test a get with group, summary, start and end
         test_cloud_view = CloudRecordSummaryView()
         factory = APIRequestFactory()
-        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
-                                       '?group=Group1',
-                                       '&service=Service1',
-                                       '&from=FromDate',
-                                       '&to=ToDate')), {})
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?group=Group1',
+                       '&service=Service1',
+                       '&from=FromDate',
+                       '&to=ToDate'))
+
+        request = factory.get(url)
 
         parsed_responses = test_cloud_view._parse_query_parameters(request)
         self.assertEqual(parsed_responses,
                          ("Group1", "Service1", "FromDate", "ToDate"))
 
         # test a get with just an end date
-        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
-                              '?to=ToDate')), {})
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?to=ToDate'))
+
+        request = factory.get(url)
         parsed_responses = test_cloud_view._parse_query_parameters(request)
         self.assertEqual(parsed_responses,
                          (None, None, None, "ToDate"))
@@ -208,14 +215,18 @@ class CloudRecordSummaryTest(TestCase):
         factory = APIRequestFactory()
 
         # test when page number is not a number
-        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
-                              '?page=a')))
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?page=a'))
+
+        request = factory.get(url)
         content = test_cloud_view._paginate_result(request, [])
         self.assertEqual(content, expected_content)
 
         # test when page number is out of bounds
-        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
-                              '?page=9999')))
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?page=9999'))
+
+        request = factory.get(url)
         content = test_cloud_view._paginate_result(request, [])
         self.assertEqual(content, expected_content)
 
@@ -223,9 +234,10 @@ class CloudRecordSummaryTest(TestCase):
         """Test a token can be extracted from request."""
         test_cloud_view = CloudRecordSummaryView()
         factory = APIRequestFactory()
-        request = factory.get(''.join((reverse('CloudRecordSummaryView'),
-                              '?from=FromDate')),
-                              HTTP_AUTHORIZATION='Bearer ThisIsAToken')
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?from=FromDate'))
+
+        request = factory.get(url, HTTP_AUTHORIZATION='Bearer ThisIsAToken')
 
         token = test_cloud_view._request_to_token(request)
         self.assertEqual(token, 'ThisIsAToken')
@@ -233,8 +245,11 @@ class CloudRecordSummaryTest(TestCase):
     def test_request_to_token_fail(self):
         """Test the response of a tokenless request."""
         test_client = Client()
-        response = test_client.get(''.join((reverse('CloudRecordSummaryView'),
-                                   '?from=FromDate')))
+
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?from=FromDate'))
+
+        response = test_client.get(url)
 
         self.assertEqual(response.status_code, 401)
 

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -111,11 +111,6 @@ class CloudRecordSummaryTest(TestCase):
         self.assertEqual(response.status_code, 401)
 
         # Test with a malformed HTTP_AUTHORIZATION header
-        url = ''.join((reverse('CloudRecordSummaryView'),
-                       '?group=TestGroup',
-                       '&from=20000101',
-                       '&to=20191231'))
-
         response = test_client.get(url,
                                    HTTP_AUTHORIZATION='TestToken')
 

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -39,12 +39,12 @@ class CloudRecordSummaryTest(TestCase):
                                            "Year"]):
 
             test_client = Client()
-            get_url = ''.join((reverse('CloudRecordSummaryView'),
-                               '?group=TestGroup',
-                               '&from=20000101',
-                               '&to=20191231'))
+            url = ''.join((reverse('CloudRecordSummaryView'),
+                           '?group=TestGroup',
+                           '&from=20000101',
+                           '&to=20191231'))
 
-            response = test_client.get(get_url,
+            response = test_client.get(url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
@@ -63,9 +63,9 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            get_url = ''.join((reverse('CloudRecordSummaryView'),
-                               '?group=TestGroup'))
-            response = test_client.get(get_url,
+            url = ''.join((reverse('CloudRecordSummaryView'),
+                          '?group=TestGroup'))
+            response = test_client.get(url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
@@ -84,12 +84,12 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            get_url = ''.join((reverse('CloudRecordSummaryView'),
-                               '?group=TestGroup',
-                               '&from=20000101',
-                               '&to=20191231'))
+            url = ''.join((reverse('CloudRecordSummaryView'),
+                           '?group=TestGroup',
+                           '&from=20000101',
+                           '&to=20191231'))
 
-            response = test_client.get(get_url,
+            response = test_client.get(url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
         # Check the expected response code has been received.
@@ -99,12 +99,12 @@ class CloudRecordSummaryTest(TestCase):
         """Test an unauthenticated GET request."""
         test_client = Client()
         # Test without the HTTP_AUTHORIZATION header
-        get_url = ''.join((reverse('CloudRecordSummaryView'),
-                           '?group=TestGroup',
-                           '&from=20000101',
-                           '&to=20191231'))
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?group=TestGroup',
+                       '&from=20000101',
+                       '&to=20191231'))
 
-        response = test_client.get(get_url)
+        response = test_client.get(url)
 
         # Check the expected response code has been received.
         self.assertEqual(response.status_code, 401)
@@ -137,12 +137,12 @@ class CloudRecordSummaryTest(TestCase):
                                            "Month",
                                            "Year"]):
             test_client = Client()
-            get_url = ''.join((reverse('CloudRecordSummaryView'),
-                               '?group=TestGroup',
-                               '&from=20000101',
-                               '&to=20191231'))
+            url = ''.join((reverse('CloudRecordSummaryView'),
+                           '?group=TestGroup',
+                           '&from=20000101',
+                           '&to=20191231'))
 
-            response = test_client.get(get_url,
+            response = test_client.get(url,
                                        HTTP_AUTHORIZATION="Bearer TestToken")
 
         expected_response = ('{'


### PR DESCRIPTION
Adds the name parameter to the `urlpatterns` to allow [reverse URL resolution](https://docs.djangoproject.com/en/1.10/topics/http/urls/#reverse-resolution-of-urls) by the test cases.
- Tests refer to urls by a name, rather than the actual url
- So if the urls change, only the `urls.py` file needs to be changed