### PR TITLE
Add example output of GET requests to documentation

### DIFF
--- a/doc/user.md
+++ b/doc/user.md
@@ -35,9 +35,42 @@ For Example:
 
 `from` is the only compulsary option, failure to include it will result in a 400 response.
 
-### Expected Responses
+### Expected Status Codes
 * 200: Your request was succesfully met.
 * 400: No key=value pair provided for from.
 * 401: Your service's OAuth token was not provided by the request, or was not successfully extracted by the server.
 * 403: Your service's OAuth token was extracted by the server, but the IAM does not recognise it.
 * 500: An unknown error has a occured.
+
+### Example Returned Results
+```
+{
+    "count": 2, 
+    "next": null, 
+    "previous": null, 
+    "results": [
+        {
+            "VOGroup": "/TEST1", 
+            "WallDuration": 86400, 
+            "UpdateTime": null, 
+            "Year": 2013, 
+            "SiteName": "Test-Site", 
+            "LatestStartTime": "2013-02-25T17:37:27", 
+            "EarliestStartTime": "2013-02-25T17:37:27", 
+            "Day": 26, 
+            "Month": 2
+        }, 
+        {
+            "VOGroup": "/TEST1", 
+            "WallDuration": 86399, 
+            "UpdateTime": null, 
+            "Year": 2013, 
+            "SiteName": "Test-Site", 
+            "LatestStartTime": "2013-02-25T17:37:27", 
+            "EarliestStartTime": "2013-02-25T17:37:27", 
+            "Day": 27, 
+            "Month": 2
+        }
+    ]
+}
+```

--- a/doc/user.md
+++ b/doc/user.md
@@ -42,7 +42,7 @@ For Example:
 * 403: Your service's OAuth token was extracted by the server, but the IAM does not recognise it.
 * 500: An unknown error has a occured.
 
-### Example Returned Results
+### Example Response Body
 ```
 {
     "count": 2, 

--- a/doc/user.md
+++ b/doc/user.md
@@ -30,8 +30,8 @@ For Example:
 
 * `group`: The group within Indigo DataCloud.
 * `service`: The site that provided the resource.
-* `to`: Display summaries for dates (YYYYMMDD) up until this value.
-* `from`: Display summaries for dates (YYYYMMDD) after this value.
+* `to`: Display summaries for dates (YYYYMMDD) up until this value, but exclusive of it.
+* `from`: Display summaries for dates (YYYYMMDD) after this value, but exclusive of it.
 
 `from` is the only compulsary option, failure to include it will result in a 400 response.
 

--- a/doc/user.md
+++ b/doc/user.md
@@ -28,10 +28,10 @@ For Example:
 
 ### Supported key=value pairs
 
-* `group`: The group with Indigo DataCloud.
+* `group`: The group within Indigo DataCloud.
 * `service`: The site that provided the resource.
 * `to`: Display summaries for dates (YYYYMMDD) up until this value.
-* `from`: Display summaries for dates (YYYYMMDD) up after this value.
+* `from`: Display summaries for dates (YYYYMMDD) after this value.
 
 `from` is the only compulsary option, failure to include it will result in a 400 response.
 


### PR DESCRIPTION
Current user documentation indicates how to access the summaries, but does not give an indication on what will be returned. As such an example output has been added.

Also added missing / removed unneeded words in the 'Supported key=value pairs' section