### PR TITLE
Allow for the Identity and Access Management (IAM) URL to be set in settings.py

### DIFF
--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -158,4 +158,8 @@ RETURN_HEADERS = ["VOGroup",
 # this doesnt do anything, probably because of using older Django
 URL_FORMAT_OVERRIDE = None
 
+# Points to the JSON list of Resource Providers
 PROVIDERS_URL = "http://indigo.cloud.plgrid.pl/cmdb/service/list"
+
+# The introspect URL for the IAM repsonsible for token based authN/authZ
+IAM_URL = "https://iam-test.indigo-datacloud.eu/introspect"

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -226,8 +226,8 @@ class CloudRecordSummaryView(APIView):
     def _token_to_id(self, token):
         """Convert a token to a IAM ID (external dependency)."""
         try:
-            iam_url = 'https://iam-test.indigo-datacloud.eu/introspect'
-            auth_request = urllib2.Request(iam_url, data='token=%s' % token)
+            auth_request = urllib2.Request(settings.IAM_URL,
+                                           data='token=%s' % token)
 
             server_id = settings.SERVER_IAM_ID
             server_secret = settings.SERVER_IAM_SECRET


### PR DESCRIPTION
remove the hard coded URL from source code in favour of a configuration option