### PR TITLE
Add Fetching of Certificate Revokation Lists to Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,9 @@ gpgkey=http://repository.egi.eu/sw/production/cas/1/GPG-KEY-EUGridPMA-RPM-3' >> 
 # install cron
 # install at (for scheduling the IGTF update after start up)
 # install IGTF trust bundle
+# install fetch-crl
 # install APEL requirements
-RUN yum -y install wget unzip python-pip python-devel mysql mysql-devel gcc httpd httpd-devel mod_wsgi mod_ssl vixie-cron at ca-policy-egi-core python-iso8601 python-ldap
+RUN yum -y install wget unzip python-pip python-devel mysql mysql-devel gcc httpd httpd-devel mod_wsgi mod_ssl vixie-cron at ca-policy-egi-core python-iso8601 python-ldap fetch-crl
 
 # get APEL codebase
 RUN wget https://github.com/apel/apel/releases/download/1.5.1-1/apel-lib-1.5.1-1.el6.noarch.rpm

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -51,6 +51,11 @@ service atd start
 # start the loader service
 service apeldbloader-cloud start
 
+# fetch the crl first
+fetch-crl
+# then start the periodic fetch-url
+service fetch-crl-cron start
+
 # Make cloud spool dir owned by apache
 chown apache -R /var/spool/apel/cloud/
 

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -39,6 +39,11 @@ SERVER_IAM_SECRET=\"$SERVER_IAM_SECRET\"
 
 sed -i "s/Put a secret here/$DJANGO_SECRET_KEY/g" /var/www/html/apel_rest/settings.py
 
+# fetch the crl first
+fetch-crl
+# then start the periodic fetch-url
+service fetch-crl-cron start
+
 # start apache
 service httpd start
 
@@ -50,11 +55,6 @@ service atd start
 
 # start the loader service
 service apeldbloader-cloud start
-
-# fetch the crl first
-fetch-crl
-# then start the periodic fetch-url
-service fetch-crl-cron start
 
 # Make cloud spool dir owned by apache
 chown apache -R /var/spool/apel/cloud/


### PR DESCRIPTION
On start-up, before starting the apache server, the docker image will now pull down the latest certificate revocation lists for the trust bundle.

They are then updated periodically (every 6 hours).

This way, if a certificate is revoked at a later date, it will no longer be able to be used to access the interface.