### PR TITLE
Add the ability to locally ban/allow POST requests

### DIFF
--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -166,6 +166,7 @@ PROVIDERS_URL = "http://indigo.cloud.plgrid.pl/cmdb/service/list"
 # The introspect URL for the IAM repsonsible for token based authN/authZ
 IAM_URL = "https://iam-test.indigo-datacloud.eu/introspect"
 
-# Use these variables to revoke/grant POST rights
-ALLOWED_FOR_POST = []
+# Use these variables to revoke/grant POST rights.
+# Remember these variables require a web server reset to take effect.
+ALLOWED_TO_POST = []
 BANNED_FROM_POST = []

--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -1,6 +1,8 @@
 """
 Django settings for apel_rest project.
 
+Any changes will require restarting the httpd server.
+
 For more information on this file, see
 https://docs.djangoproject.com/en/1.6/topics/settings/
 

--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -167,6 +167,6 @@ PROVIDERS_URL = "http://indigo.cloud.plgrid.pl/cmdb/service/list"
 IAM_URL = "https://iam-test.indigo-datacloud.eu/introspect"
 
 # Use these variables to revoke/grant POST rights.
-# Remember these variables require a web server reset to take effect.
+# Remember these variables require a web server restart to take effect.
 ALLOWED_TO_POST = []
 BANNED_FROM_POST = []

--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -163,3 +163,7 @@ PROVIDERS_URL = "http://indigo.cloud.plgrid.pl/cmdb/service/list"
 
 # The introspect URL for the IAM repsonsible for token based authN/authZ
 IAM_URL = "https://iam-test.indigo-datacloud.eu/introspect"
+
+# Use these variables to revoke/grant POST rights
+ALLOWED_FOR_POST = []
+BANNED_FROM_POST = []

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -54,7 +54,7 @@ class CloudRecordTest(TestCase):
         For that, see test_cloud_record_post_202()
         """
         example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=special_host.test"
-        with self.settings(ALLOWED_FOR_POST=[example_dn],
+        with self.settings(ALLOWED_TO_POST=[example_dn],
                            QPATH=QPATH_TEST):
 
             # Mock the functionality of the provider list

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -65,7 +65,6 @@ class CloudRecordTest(TestCase):
                                         SSL_CLIENT_S_DN=example_dn)
 
             self.assertEqual(response.status_code, 202)
-            self._delete_messages(QPATH_TEST)
 
     def test_cloud_record_post_provider_fail(self):
         """Test what happens if we fail to retrieve the providers."""
@@ -156,10 +155,10 @@ class CloudRecordTest(TestCase):
 
             # check saved message content
             self.assertEqual(MESSAGE, message_content)
-            self._delete_messages(QPATH_TEST)
 
     def tearDown(self):
         """Delete any messages under QPATH and re-enable logging.INFO."""
+        self._delete_messages(QPATH_TEST)
         logging.disable(logging.NOTSET)
 
     def _delete_messages(self, message_path):

--- a/api/tests/test_cloud_record.py
+++ b/api/tests/test_cloud_record.py
@@ -24,11 +24,7 @@ class CloudRecordTest(TestCase):
         logging.disable(logging.CRITICAL)
 
     def test_cloud_record_post_provider_banned(self):
-        """
-        Test a banned provider cannot POST.
-
-        Even if they are on the provider list.
-        """
+        """Test that a banned provider on the provider list cannot POST."""
         example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=allowed_host.test"
         with self.settings(BANNED_FROM_POST=[example_dn]):
 
@@ -47,10 +43,10 @@ class CloudRecordTest(TestCase):
 
     def test_cloud_record_post_provider_special(self):
         """
-        Test a provider ganted POST rights can, indeed, POST.
+        Test that a provider granted POST rights can, indeed, POST.
 
         Even if they aren't on the provider list.
-        This test DOES NOT check the saved message is correct.
+        This test DOES NOT check that the saved message is correct.
         For that, see test_cloud_record_post_202()
         """
         example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=special_host.test"

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -139,7 +139,7 @@ class CloudRecordView(APIView):
                 # Continue looping through provider list, looking
                 # for a match in the remaining site JSON
 
-        if signer_dn in settings.ALLOWED_FOR_POST:
+        if signer_dn in settings.ALLOWED_TO_POST:
             self.logger.info("Host %s has special access.", signer)
             return True
 

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -113,6 +113,14 @@ class CloudRecordView(APIView):
         signer_split = signer_dn.split("=")
         signer = signer_split[len(signer_split)-1]
 
+        if signer in settings.BANNED_FROM_POST:
+            self.logger.info("Host %s is banned.", signer)
+            return False
+
+        if signer in settings.ALLOWED_FOR_POST:
+            self.logger.info("Host %s has special access.", signer)
+            return True
+
         providers = self._get_provider_list()
 
         try:
@@ -130,8 +138,8 @@ class CloudRecordView(APIView):
             except KeyError:
                 # A KeyError is thrown if a hostname is not defined.
                 # Log that a single site could not be parsed
-                logging.warning('Could not parse site JSON.')
-                logging.debug(site_json)
+                self.logger.warning('Could not parse site JSON.')
+                self.logger.debug(site_json)
                 # Continue looping through provider list, looking
                 # for a match in the remaining site JSON
 

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -117,10 +117,6 @@ class CloudRecordView(APIView):
             self.logger.info("Host %s is banned.", signer)
             return False
 
-        if signer in settings.ALLOWED_FOR_POST:
-            self.logger.info("Host %s has special access.", signer)
-            return True
-
         providers = self._get_provider_list()
 
         try:
@@ -143,7 +139,11 @@ class CloudRecordView(APIView):
                 # Continue looping through provider list, looking
                 # for a match in the remaining site JSON
 
-        # If we have not returned while in the above
-        # for loop then site must be invalid
+        if signer in settings.ALLOWED_FOR_POST:
+            self.logger.info("Host %s has special access.", signer)
+            return True
+
+        # If we have not returned already
+        # then site must be invalid
         self.logger.info('Site is not found on list of providers')
         return False

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -113,7 +113,7 @@ class CloudRecordView(APIView):
         signer_split = signer_dn.split("=")
         signer = signer_split[len(signer_split)-1]
 
-        if signer in settings.BANNED_FROM_POST:
+        if signer_dn in settings.BANNED_FROM_POST:
             self.logger.info("Host %s is banned.", signer)
             return False
 
@@ -139,7 +139,7 @@ class CloudRecordView(APIView):
                 # Continue looping through provider list, looking
                 # for a match in the remaining site JSON
 
-        if signer in settings.ALLOWED_FOR_POST:
+        if signer_dn in settings.ALLOWED_FOR_POST:
             self.logger.info("Host %s has special access.", signer)
             return True
 

--- a/doc/service_reference_card.md
+++ b/doc/service_reference_card.md
@@ -45,7 +45,7 @@
   
   * How to block/ban a user
     * To ban users accessing summaries, remove them from `ALLOWED_FOR_GET` in `/var/www/html/apel_rest/settings.py`.
-    * To ban users sending job records, add their HostDN to `BANNED_FROM_POST in `/var/www/html/apel_rest/settings.py`.
+    * To ban users sending job records, add their HostDN to `BANNED_FROM_POST` in `/var/www/html/apel_rest/settings.py`.
  
   * Network Usage
     * Managed by the Kubernetes cluster.

--- a/doc/service_reference_card.md
+++ b/doc/service_reference_card.md
@@ -46,7 +46,7 @@
   * How to block/ban a user
     * To ban users accessing summaries, remove them from `ALLOWED_FOR_GET` in `/var/www/html/apel_rest/settings.py`.
     * To ban users sending job records, add their HostDN to `BANNED_FROM_POST` in `/var/www/html/apel_rest/settings.py`.
-    * Users can also be granted POST rights, by adding their HostDN to `ALLOWED_FOR_POST` in `/var/www/html/apel_rest/settings.py`.
+    * Users can also be granted POST rights, by adding their HostDN to `ALLOWED_TO_POST` in `/var/www/html/apel_rest/settings.py`.
     * Any changes to `/var/www/html/apel_rest/settings.py` require a `service httpd restart` to take effect.
  
   * Network Usage

--- a/doc/service_reference_card.md
+++ b/doc/service_reference_card.md
@@ -45,7 +45,8 @@
   
   * How to block/ban a user
     * To ban users accessing summaries, remove them from `ALLOWED_FOR_GET` in `/var/www/html/apel_rest/settings.py`.
-    * To ban users sending job records, add their HostDN to `BANNED_FROM_POST` in `/var/www/html/apel_rest/settings.py`.
+    * To ban users sending job records, perhaps because a provider in the Indigo provider list is negatively effecting
+      the quality of the service for users by bulk reppublishing, add their HostDN to `BANNED_FROM_POST` in `/var/www/html/apel_rest/settings.py`.
     * Users can also be granted POST rights, by adding their HostDN to `ALLOWED_TO_POST` in `/var/www/html/apel_rest/settings.py`.
     * Any changes to `/var/www/html/apel_rest/settings.py` require a `service httpd restart` to take effect.
  

--- a/doc/service_reference_card.md
+++ b/doc/service_reference_card.md
@@ -46,6 +46,8 @@
   * How to block/ban a user
     * To ban users accessing summaries, remove them from `ALLOWED_FOR_GET` in `/var/www/html/apel_rest/settings.py`.
     * To ban users sending job records, add their HostDN to `BANNED_FROM_POST` in `/var/www/html/apel_rest/settings.py`.
+    * Users can also be granted POST rights, by adding their HostDN to `ALLOWED_FOR_POST` in `/var/www/html/apel_rest/settings.py`.
+    * Any changes to `/var/www/html/apel_rest/settings.py` require a `service httpd restart` to take effect.
  
   * Network Usage
     * Managed by the Kubernetes cluster.

--- a/doc/service_reference_card.md
+++ b/doc/service_reference_card.md
@@ -47,7 +47,7 @@
     * To ban users accessing summaries, remove them from `ALLOWED_FOR_GET` in `/var/www/html/apel_rest/settings.py`.
     * To ban users sending job records, perhaps because a provider in the Indigo provider list is negatively effecting
       the quality of the service for users by bulk reppublishing, add their HostDN to `BANNED_FROM_POST` in `/var/www/html/apel_rest/settings.py`.
-    * Users can also be granted POST rights, by adding their HostDN to `ALLOWED_TO_POST` in `/var/www/html/apel_rest/settings.py`.
+    * Additional users, not on the providers list, can also be granted POST rights, by adding their HostDN to `ALLOWED_TO_POST` in `/var/www/html/apel_rest/settings.py`.
     * Any changes to `/var/www/html/apel_rest/settings.py` require a `service httpd restart` to take effect.
  
   * Network Usage

--- a/doc/service_reference_card.md
+++ b/doc/service_reference_card.md
@@ -45,7 +45,7 @@
   
   * How to block/ban a user
     * To ban users accessing summaries, remove them from `ALLOWED_FOR_GET` in `/var/www/html/apel_rest/settings.py`.
-    * While no explicit means of blocking a POST request currently exists, for a POST request to be authorized it must be listed as an Indigo DataCloud provider. So providers could be banned for the entire Indigo architecture. 
+    * To ban users sending job records, add their HostDN to `BANNED_FROM_POST in `/var/www/html/apel_rest/settings.py`.
  
   * Network Usage
     * Managed by the Kubernetes cluster.


### PR DESCRIPTION
POST endpoint will now AuthZ requests in the following order
- if the DN has been explicitly banned (added to `BANNED_FROM_POST`), do not allow.
- if the hostname in the DN is a listed provider, allow
- if the DN has been explicitly set to be allowed (added to `ALLOW_FOR_POST`), then allow

Test cases have been added to check this behaviour.

Banning users has been documented in the service reference card.