### PR TITLE
Replace default cursor object with a DictCursor

### DIFF
--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -270,9 +270,9 @@ class CloudRecordSummaryTest(TestCase):
 
         # A list of test summaries.
         test_data = [{'Day': 30,
-                     'Month': 7,
-                     'Year': 2016,
-                     'SiteName': 'TEST'}]
+                      'Month': 7,
+                      'Year': 2016,
+                      'SiteName': 'TEST'}]
 
         cursor = Mock()
         # Get the mock cursor object return the test_data.

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -268,24 +268,23 @@ class CloudRecordSummaryTest(TestCase):
         """Test the filtering of a query object based on settings."""
         test_cloud_view = CloudRecordSummaryView()
 
-        # this approximates a cursor object
-        # in future, a cursor dict may be better
-        # to use in _filter_cursor
-        cursor_headers = [['SiteName'], ['Day'], ['Month'], ['Year']]
-        cursor_data = [[['SiteName', 'Test'],
-                        ['Day', 01],
-                        ['Month', 02],
-                        ['Year', 2000]]]
+        # A list of test summaries.
+        test_data = [{'Day': 30,
+                     'Month': 7,
+                     'Year': 2016,
+                     'SiteName': 'TEST'}]
 
         cursor = Mock()
-        cursor.description = cursor_headers
-        cursor.fetchall = Mock(return_value=cursor_data)
+        # Get the mock cursor object return the test_data.
+        cursor.fetchall = Mock(return_value=test_data)
 
         with self.settings(RETURN_HEADERS=['SiteName', 'Day']):
             result = test_cloud_view._filter_cursor(cursor)
 
-        expected_result = [{'SiteName': ['SiteName', 'Test'],
-                            'Day': ['Day', 1]}]
+        expected_result = [{'SiteName': 'TEST',
+                            'Day': 30}]
+
+        # Check the result is as expected.
         self.assertEqual(result, expected_result)
 
     def tearDown(self):

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -284,7 +284,6 @@ class CloudRecordSummaryTest(TestCase):
         expected_result = [{'SiteName': 'TEST',
                             'Day': 30}]
 
-        # Check the result is as expected.
         self.assertEqual(result, expected_result)
 
     def tearDown(self):

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -111,7 +111,7 @@ class CloudRecordSummaryView(APIView):
                               db_name, db_hostname, db_username, db_password)
             return Response(status=500)
 
-        cursor = database.cursor()
+        cursor = database.cursor(MySQLdb.cursors.DictCursor)
 
         if group_name is not None:
             cursor.execute('select * from VCloudSummaries '
@@ -193,15 +193,13 @@ class CloudRecordSummaryView(APIView):
         return serializer.data
 
     def _filter_cursor(self, cursor):
-        """Filter database results based on setting.RETURN_HEADERS."""
-        columns = cursor.description
+        """Filter database results based on settings.RETURN_HEADERS."""
         results = []
-        for value in cursor.fetchall():
+        for data in cursor.fetchall():
             result = {}
-            for index, column in enumerate(value):
-                header = columns[index][0]
-                if header in settings.RETURN_HEADERS:
-                    result.update({header: column})
+            for key, value in data.iteritems():
+                if key in settings.RETURN_HEADERS:
+                    result.update({key: value})
             results.append(result)
 
         return results

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -194,7 +194,7 @@ class CloudRecordSummaryView(APIView):
 
     def _filter_cursor(self, cursor):
         """Filter database results based on settings.RETURN_HEADERS."""
-        results = []  # Return list.
+        results_list = []  # Return list.
         for record in cursor.fetchall():  # record refers to one days summary
             # Construct a new summary with only the values we care about.
             result = {}
@@ -204,9 +204,9 @@ class CloudRecordSummaryView(APIView):
                 if key in settings.RETURN_HEADERS:
                     result.update({key: value})
             # Append new Dictionary to return list.
-            results.append(result)
+            results_list.append(result)
 
-        return results
+        return results_list
 
     def _request_to_token(self, request):
         """Get the token from the request."""

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -194,12 +194,16 @@ class CloudRecordSummaryView(APIView):
 
     def _filter_cursor(self, cursor):
         """Filter database results based on settings.RETURN_HEADERS."""
-        results = []
-        for data in cursor.fetchall():
+        results = []  # Return list.
+        for record in cursor.fetchall(): # record refers to one days summary
+            # Construct a new summary with only the values we care about.
             result = {}
-            for key, value in data.iteritems():
-                if key in settings.RETURN_HEADERS:
+            for key, value in record.iteritems():
+                # If the key is int settings.RETURN_HEADERS, add it
+                # to the new Dictionary.
+                if key in settings.RETURN_HEADERS:  
                     result.update({key: value})
+            # Append new Dictionary to return list.
             results.append(result)
 
         return results

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -195,13 +195,13 @@ class CloudRecordSummaryView(APIView):
     def _filter_cursor(self, cursor):
         """Filter database results based on settings.RETURN_HEADERS."""
         results = []  # Return list.
-        for record in cursor.fetchall(): # record refers to one days summary
+        for record in cursor.fetchall():  # record refers to one days summary
             # Construct a new summary with only the values we care about.
             result = {}
             for key, value in record.iteritems():
                 # If the key is int settings.RETURN_HEADERS, add it
                 # to the new Dictionary.
-                if key in settings.RETURN_HEADERS:  
+                if key in settings.RETURN_HEADERS:
                     result.update({key: value})
             # Append new Dictionary to return list.
             results.append(result)

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -193,17 +193,27 @@ class CloudRecordSummaryView(APIView):
         return serializer.data
 
     def _filter_cursor(self, cursor):
-        """Filter database results based on settings.RETURN_HEADERS."""
-        results_list = []  # Return list.
-        for record in cursor.fetchall():  # record refers to one days summary
-            # Construct a new summary with only the values we care about.
+        """
+        Filter database results based on settings.RETURN_HEADERS.
+
+        Allows for configuration of what summary fields
+        the REST interface returns on GET requests.
+        """
+        results_list = []
+        # Use results_list to store individual summaries to before returning.
+        for record in cursor.fetchall():
+            # record refers to one day's summary
             result = {}
+            # result is used to construct a new, filtered, summary with
+            # only the values listed in settings.RETURN_HEADERS.
             for key, value in record.iteritems():
-                # If the key is int settings.RETURN_HEADERS, add it
-                # to the new Dictionary.
                 if key in settings.RETURN_HEADERS:
+                    # keys listed in settings.RETURN_HEADERS represent
+                    # summary fields the REST interface has been configured
+                    # to return. As such we need to add that field to the
+                    # new summary we are constructing
                     result.update({key: value})
-            # Append new Dictionary to return list.
+
             results_list.append(result)
 
         return results_list


### PR DESCRIPTION
This change makes the code responsible for filtering returned values slightly more readable, as it doesn't use terms like column and index, but rather key, value pairs

It also improves the readability of the test case, as the mocked data is a dictionary, rather than separate lists of headers and a nested list of data