### PR TITLE
Add a simple script to sender to the APEL REST interface

### DIFF
--- a/doc/user.md
+++ b/doc/user.md
@@ -8,7 +8,7 @@ Providers can publish accounting records to the endpoint:
 
 To do this, Providers must be running OpenStack or OpenNebula and install the appropriate collectors. Links to these can be found at [List of Artifacts](https://indigo-dc.gitbooks.io/indigo-datacloud-releases/content/indigo1/accounting1.html)
 
-Records can be sent to the REST interface using this [script](scripts/sender.py). To do so, populate the variables in `main()` and run `python sender.py` after running the appropriate collector.
+Records can be sent to the REST interface using this [script](scripts/sender.py). Run `python sender.py -h` for a list of options that need to be set in order to send.
 
 ### Expected Responses
 * 202: The data has been successfully saved for future loading and summarising.

--- a/doc/user.md
+++ b/doc/user.md
@@ -8,6 +8,8 @@ Providers can publish accounting records to the endpoint:
 
 To do this, Providers must be running OpenStack or OpenNebula and install the appropriate collectors. Links to these can be found at [List of Artifacts](https://indigo-dc.gitbooks.io/indigo-datacloud-releases/content/indigo1/accounting1.html)
 
+Records can be sent to the REST interface using this [script](scripts/sender.py). To do so, populate the variables in `main()` and run `python sender.py` after running the appropriate collector.
+
 ### Expected Responses
 * 202: The data has been successfully saved for future loading and summarising.
 * 401: An X.509 certifcate was not provided by the request, your data was not saved.

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -7,6 +7,7 @@ send messages to the REST endpoint defined in main().
 """
 
 
+import argparse
 import httplib
 import json
 import logging
@@ -98,23 +99,61 @@ class Sender(object):
 
 
 def main():
-    """Configure a Sender and send Records to an APEL REST interface."""
-    # The web address of the accounting server you wish to send to
-    # e.g. accounting.indigio-datacloud.eu
-    dest = ''
-    # The directory to read saved accounting messages from
-    # e.g. /var/spool/apel/cloud
-    qpath = ''
-    # The location of this machine's private key
-    # e.g. /etc/httpd/ssl/key.file
-    key = ''
-    # The location of this machine's X.509 certifcate
-    # e.g. /etc/httpd/ssl/cert.file
-    cert = ''
-    # Version of the APEL REST API Version, expected to be v1
-    version = 'v1'
+    """
+    Configure a Sender and send Records to an APEL REST interface.
 
-    sender = Sender(dest, qpath, cert, key, version)
+    Usage:
+    sender.py -d DESTINATION -q QUEUE -k KEY -c CERTIFICATE -v VERSION
+
+    Options:
+    -h, --help        show this help message and exit
+    -d DESTINATION, --destination DESTINATION
+                      The web address of the accounting server you wish to
+                      send to. e.g. accounting.indigio-datacloud.eu
+    -q QUEUE, --queue QUEUE
+                      The directory to read saved accounting messages from.
+                      e.g. /var/spool/apel/cloud
+    -k KEY, --key KEY
+                      The path to this machine's private key. e.g.
+                      /etc/httpd/ssl/key.file
+    -c CERTIFICATE, --certificate CERTIFICATE
+                      The location of this machine's X.509 certifcate. e.g.
+                      /etc/httpd/ssl/cert.file
+    -v VERSION, --version VERSION
+                      Version of the APEL REST API Version, expected to be
+                      v1
+    """
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument("-d", "--destination", type=str, required=True,
+                            help=("The web address of the accounting "
+                                  "server you wish to send to. "
+                                  "e.g. accounting.indigio-datacloud.eu"))
+
+    arg_parser.add_argument("-q", "--queue", type=str, required=True,
+                            help=("The directory to read saved accounting "
+                                  " messages from. "
+                                  "e.g. /var/spool/apel/cloud"))
+
+    arg_parser.add_argument("-k", "--key", type=str, required=True,
+                            help=("The path to this machine's private key. "
+                                  "e.g. /etc/httpd/ssl/key.file"))
+
+    arg_parser.add_argument("-c", "--certificate", type=str, required=True,
+                            help=("The location of this "
+                                  "machine's X.509 certifcate. "
+                                  "e.g. /etc/httpd/ssl/cert.file"))
+
+    arg_parser.add_argument("-v", "--version", type=str, required=True,
+                            help=("Version of the APEL REST API Version, "
+                                  "expected to be v1"))
+
+    args = arg_parser.parse_args()
+
+    sender = Sender(args.destination,
+                    args.queue,
+                    args.certificate,
+                    args.key,
+                    args.version)
 
     sender.send_all()
 

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -100,13 +100,16 @@ def main():
     """Configure a Sender and send Records to an APEL REST interface."""
     # The web address of the accounting server you wish to send to
     # i.e accounting.indigio-datacloud.eu
-    dest = 
+    dest = ''
     # The directory to read saved accounting messages to
-    qpath = 
+    # i.e /var/spool/apel/cloud
+    qpath = ''
     # The location of this machines private key
-    key = 
+    # i.e. /etc/httpd/ssl/key.file
+    key = ''
     # The location of this machines X.509 certifcate
-    cert = 
+    # i.e. /etc/httpd/ssl/cert.file
+    cert = ''
 
     sender = Sender(dest, qpath, cert, key)
 

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -103,7 +103,7 @@ def main():
     Configure a Sender and send Records to an APEL REST interface.
 
     Usage:
-    sender.py -d DESTINATION -q QUEUE -k KEY -c CERTIFICATE -v VERSION
+    sender.py -d DESTINATION -q QUEUE -k KEY -c CERTIFICATE [-v VERSION]
 
     Options:
     -h, --help        show this help message and exit
@@ -143,7 +143,7 @@ def main():
                                   "machine's X.509 certifcate. "
                                   "e.g. /etc/httpd/ssl/cert.file"))
 
-    arg_parser.add_argument("-v", "--version", type=str, required=True,
+    arg_parser.add_argument("-v", "--version", type=str, default="v1",
                             help=("Version of the APEL REST API Version, "
                                   "expected to be v1"))
 

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -1,0 +1,119 @@
+"""
+This module contains a simple class for sending Accounting Records.
+
+Accounting Records are sent to a REST endpoint.
+If run as a python script, this module will
+send messages to the REST endpoint defined in main().
+"""
+
+import ssl
+
+from dirq.QueueSimple import QueueSimple
+
+import os
+import socket
+import time
+import logging
+import httplib
+import json
+import sys
+
+log = logging.getLogger(__name__)
+
+
+class Sender():
+    """A simple class for sending Accounting Records to a REST endpoint."""
+
+    def __init__(self, dest, qpath, cert, key):
+        """Initialize a Sender."""
+        self._cert = cert
+        self._key = key
+        self._outq = QueueSimple(qpath)
+        self._dest = dest
+
+    def send_all(self):
+        """Send all the messages in the outgoing queue via REST."""
+        log.info('Found %s messages.', self._outq.count())
+        for msgid in self._outq:
+            if not self._outq.lock(msgid):
+                log.warn('Message was locked. %s will not be sent.', msgid)
+                continue
+
+            text = self._outq.get(msgid)
+
+            url = '/api/v1/cloud/record'
+            data = text
+
+            self._rest_connect('POST', url, data, {}, 202)
+            log.info("Sent %s", msgid)
+
+            time.sleep(0.1)
+
+            self._outq.remove(msgid)
+
+        log.info('Tidying message directory.')
+        try:
+            # Remove empty dirs and unlock msgs older than 5 min (default)
+            self._outq.purge()
+        except OSError, e:
+            log.warn('OSError raised while purging message queue: %s', e)
+
+    def _rest_connect(self, verb, url, data, headers, expected_response_code):
+        """
+        Send a HTTPS request to self._dest.
+
+        Will attempt to repeat if expected_response is not returned.
+        """
+        attempt_number = 0
+
+        while attempt_number < 3:
+            try:
+                attempt_number = attempt_number + 1
+
+                conn = httplib.HTTPSConnection(self._dest,
+                                               cert_file=self._cert,
+                                               key_file=self._key,
+                                               strict=False)
+
+                conn.request(verb, url, json.dumps(data), headers)
+
+                response = conn.getresponse()
+
+                if response.status == expected_response_code:
+                    return response
+                else:
+                    log.warning("Could not connect to endpoint, retrying")
+                    time.sleep(attempt_number)
+                    continue
+
+            except socket.gaierror as e:
+                log.info('socket.gaierror: %s, %s',
+                         e.errno, e.strerror)
+                sys.exit()
+
+        # if here, attempt_number has been exceeded
+        log.info('Could not connect to endpoint. Error: %s - %s',
+                 response.status, response.reason)
+        sys.exit()
+
+
+def main():
+    """Configure a Sender and send Records to an APEL REST interface."""
+    # The web address of the accounting server you wish to send to
+    # i.e accounting.indigio-datacloud.eu
+    dest =
+    # The directory to read saved accounting messages to
+    qpath =
+    # The location of this machines private key
+    key =
+    # The location of this machines X.509 certifcate
+    cert =
+
+    sender = Sender(dest, qpath, cert, key)
+
+    sender._outq.add('BOOP')
+
+    sender.send_all()
+
+if __name__ == '__main__':
+    main()

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -68,7 +68,7 @@ class Sender(object):
 
         while attempt_number < 3:
             try:
-                attempt_number = attempt_number + 1
+                attempt_number += 1
 
                 conn = httplib.HTTPSConnection(self._dest,
                                                cert_file=self._cert,

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -44,7 +44,7 @@ class Sender(object):
             path = '/api/%s/cloud/record' % self._api_version
             data = text
 
-            self._rest_connect('POST', path, data, {}, 202)
+            self._rest_send('POST', path, data, {}, 202)
             log.info("Sent %s", msgid)
 
             time.sleep(0.1)
@@ -58,7 +58,7 @@ class Sender(object):
         except OSError, e:
             log.warn('OSError raised while purging message queue: %s', e)
 
-    def _rest_connect(self, verb, path, data, headers, expected_response_code):
+    def _rest_send(self, verb, path, data, headers, expected_response_code):
         """
         Send a HTTPS request to self._dest.
 

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -60,7 +60,7 @@ class Sender(object):
 
     def _rest_send(self, verb, path, data, headers, expected_response_code):
         """
-        Send a HTTPS request to self._dest.
+        Send an HTTPS request to self._dest.
 
         Will attempt to repeat if expected_response is not returned.
         """

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -89,12 +89,12 @@ class Sender(object):
             except socket.gaierror as e:
                 log.info('socket.gaierror: %s, %s',
                          e.errno, e.strerror)
-                sys.exit()
+                sys.exit(1)
 
         # if here, attempt_number has been exceeded
         log.info('Could not connect to endpoint. Error: %s - %s',
                  response.status, response.reason)
-        sys.exit()
+        sys.exit(1)
 
 
 def main():

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -41,10 +41,10 @@ class Sender(object):
 
             text = self._outq.get(msgid)
 
-            url = '/api/%s/cloud/record' % self._api_version
+            path = '/api/%s/cloud/record' % self._api_version
             data = text
 
-            self._rest_connect('POST', url, data, {}, 202)
+            self._rest_connect('POST', path, data, {}, 202)
             log.info("Sent %s", msgid)
 
             time.sleep(0.1)
@@ -58,7 +58,7 @@ class Sender(object):
         except OSError, e:
             log.warn('OSError raised while purging message queue: %s', e)
 
-    def _rest_connect(self, verb, url, data, headers, expected_response_code):
+    def _rest_connect(self, verb, path, data, headers, expected_response_code):
         """
         Send a HTTPS request to self._dest.
 
@@ -75,7 +75,7 @@ class Sender(object):
                                                key_file=self._key,
                                                strict=False)
 
-                conn.request(verb, url, json.dumps(data), headers)
+                conn.request(verb, path, json.dumps(data), headers)
 
                 response = conn.getresponse()
 

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -102,7 +102,7 @@ def main():
     # The web address of the accounting server you wish to send to
     # e.g. accounting.indigio-datacloud.eu
     dest = ''
-    # The directory to read saved accounting messages to
+    # The directory to read saved accounting messages from
     # e.g. /var/spool/apel/cloud
     qpath = ''
     # The location of this machines private key

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -6,17 +6,16 @@ If run as a python script, this module will
 send messages to the REST endpoint defined in main().
 """
 
-import ssl
 
-from dirq.QueueSimple import QueueSimple
-
-import os
-import socket
-import time
-import logging
 import httplib
 import json
+import logging
+import ssl
+import socket
 import sys
+import time
+
+from dirq.QueueSimple import QueueSimple
 
 log = logging.getLogger(__name__)
 
@@ -101,17 +100,15 @@ def main():
     """Configure a Sender and send Records to an APEL REST interface."""
     # The web address of the accounting server you wish to send to
     # i.e accounting.indigio-datacloud.eu
-    dest =
+    dest = 
     # The directory to read saved accounting messages to
-    qpath =
+    qpath = 
     # The location of this machines private key
-    key =
+    key = 
     # The location of this machines X.509 certifcate
-    cert =
+    cert = 
 
     sender = Sender(dest, qpath, cert, key)
-
-    sender._outq.add('BOOP')
 
     sender.send_all()
 

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -100,16 +100,16 @@ class Sender(object):
 def main():
     """Configure a Sender and send Records to an APEL REST interface."""
     # The web address of the accounting server you wish to send to
-    # i.e accounting.indigio-datacloud.eu
+    # e.g. accounting.indigio-datacloud.eu
     dest = ''
     # The directory to read saved accounting messages to
-    # i.e /var/spool/apel/cloud
+    # e.g. /var/spool/apel/cloud
     qpath = ''
     # The location of this machines private key
-    # i.e. /etc/httpd/ssl/key.file
+    # e.g. /etc/httpd/ssl/key.file
     key = ''
     # The location of this machines X.509 certifcate
-    # i.e. /etc/httpd/ssl/cert.file
+    # e.g. /etc/httpd/ssl/cert.file
     cert = ''
     # Version of the APEL REST API Version, expected to be v1
     version = 'v1'

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -23,12 +23,13 @@ log = logging.getLogger(__name__)
 class Sender(object):
     """A simple class for sending Accounting Records to a REST endpoint."""
 
-    def __init__(self, dest, qpath, cert, key):
+    def __init__(self, dest, qpath, cert, key, api_version):
         """Initialize a Sender."""
         self._cert = cert
         self._key = key
         self._outq = QueueSimple(qpath)
         self._dest = dest
+        self._api_version = api_version
 
     def send_all(self):
         """Send all the messages in the outgoing queue via REST."""
@@ -40,7 +41,7 @@ class Sender(object):
 
             text = self._outq.get(msgid)
 
-            url = '/api/v1/cloud/record'
+            url = '/api/%s/cloud/record' % self._api_version
             data = text
 
             self._rest_connect('POST', url, data, {}, 202)
@@ -110,8 +111,10 @@ def main():
     # The location of this machines X.509 certifcate
     # i.e. /etc/httpd/ssl/cert.file
     cert = ''
+    # Version of the APEL REST API Version, expected to be v1
+    version = 'v1'
 
-    sender = Sender(dest, qpath, cert, key)
+    sender = Sender(dest, qpath, cert, key, version)
 
     sender.send_all()
 

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -20,7 +20,7 @@ from dirq.QueueSimple import QueueSimple
 log = logging.getLogger(__name__)
 
 
-class Sender():
+class Sender(object):
     """A simple class for sending Accounting Records to a REST endpoint."""
 
     def __init__(self, dest, qpath, cert, key):

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -105,10 +105,10 @@ def main():
     # The directory to read saved accounting messages from
     # e.g. /var/spool/apel/cloud
     qpath = ''
-    # The location of this machines private key
+    # The location of this machine's private key
     # e.g. /etc/httpd/ssl/key.file
     key = ''
-    # The location of this machines X.509 certifcate
+    # The location of this machine's X.509 certifcate
     # e.g. /etc/httpd/ssl/cert.file
     cert = ''
     # Version of the APEL REST API Version, expected to be v1


### PR DESCRIPTION
A standalone send via REST script based off the prototype SSM REST methods.

Using this replaces the need for using the SSM prototype in Indigo.