### PR TITLE
Adds ability to query summaries by GlobalUserName

### DIFF
--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -154,7 +154,8 @@ RETURN_HEADERS = ["VOGroup",
                   "LatestStartTime",
                   "Day",
                   "Month",
-                  "Year"]
+                  "Year",
+                  "GlobalUserName"]
 
 # this should hide the GET?format button
 # this doesnt do anything, probably because of using older Django

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -170,20 +170,22 @@ class CloudRecordSummaryTest(TestCase):
 
     def test_parse_query_parameters(self):
         """Test the parsing of query parameters."""
-        # test a get with group, summary, start and end
+        # test a get with group, summary, start, end and user
         test_cloud_view = CloudRecordSummaryView()
         factory = APIRequestFactory()
         url = ''.join((reverse('CloudRecordSummaryView'),
                        '?group=Group1',
                        '&service=Service1',
                        '&from=FromDate',
-                       '&to=ToDate'))
+                       '&to=ToDate',
+                       '&user=UserA'))
 
         request = factory.get(url)
 
         parsed_responses = test_cloud_view._parse_query_parameters(request)
         self.assertEqual(parsed_responses,
-                         ("Group1", "Service1", "FromDate", "ToDate"))
+                         ("Group1", "Service1", "FromDate",
+                          "ToDate", "UserA"))
 
         # test a get with just an end date
         url = ''.join((reverse('CloudRecordSummaryView'),
@@ -192,7 +194,8 @@ class CloudRecordSummaryTest(TestCase):
         request = factory.get(url)
         parsed_responses = test_cloud_view._parse_query_parameters(request)
         self.assertEqual(parsed_responses,
-                         (None, None, None, "ToDate"))
+                         (None, None, None,
+                          "ToDate", None))
 
     def test_paginate_result(self):
         """Test an empty result is paginated correctly."""

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -22,6 +22,11 @@ class CloudRecordSummaryView(APIView):
 
     Usage:
 
+    .../api/v1/cloud/record/summary?user=<global_user_name>&from=<date_from>&to=<date_to>
+
+    Will return the summary for global_user_name at all services,
+    between date_from and date_to as daily summaries
+
     .../api/v1/cloud/record/summary?group=<group_name>&from=<date_from>&to=<date_to>
 
     Will return the summary for group_name at all services,
@@ -44,6 +49,11 @@ class CloudRecordSummaryView(APIView):
     def get(self, request, format=None):
         """
         Retrieve Cloud Accounting Summaries.
+
+        .../api/v1/cloud/record/summary?user=<global_user_name>&from=<date_from>&to=<date_to>
+
+        Will return the summary for global_user_name at all services,
+        between date_from and date_to as daily summaries
 
         .../api/v1/cloud/record/summary?group=<group_name>&from=<date_from>&to=<date_to>
 

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -86,6 +86,18 @@ class CloudRecordSummaryView(APIView):
          end_date,
          global_user_name) = self._parse_query_parameters(request)
 
+        # Check that at most one of group_name, service_name
+        # and global_user_name is set
+        parameters_to_check = (group_name, service_name, global_user_name)
+
+        # for each variable in parameters_to_check that
+        # is not none, increment set_count
+        set_count = sum([1 for para in parameters_to_check if para is None])
+        if set_count <= 1:
+            self.logger.error("User, Group and/or Service combined.")
+            self.logger.error("Rejecting request.")
+            return Response(status=400)
+
         if start_date is None:
             # querying without a from is not supported
             return Response(status=400)

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -100,11 +100,13 @@ class CloudRecordSummaryView(APIView):
         if set_count <= 1:
             self.logger.error("User, Group and/or Service combined.")
             self.logger.error("Rejecting request.")
-            return Response(status=400)
+            return Response("Only one of User, Group and Service can be set.",
+                            status=400)
 
         if start_date is None:
             # querying without a from is not supported
-            return Response(status=400)
+            return Response("'from' must be set in GET requests.",
+                            status=400)
 
         # Read configuration from file
         try:

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -38,7 +38,9 @@ class CloudRecordSummaryView(APIView):
     between date_from and date_to (exclusive) as daily summaries
 
     .../api/v1/cloud/record/summary?from=<date_from>
-    Will give summary for whole infrastructure from date_from (exclusive) to now
+
+    Will give summary for whole infrastructure from date_from
+    (exclusive) to now
     """
 
     def __init__(self):
@@ -66,7 +68,9 @@ class CloudRecordSummaryView(APIView):
         between date_from and date_to (exclusive) as daily summaries
 
         .../api/v1/cloud/record/summary?from=<date_from>
-        Will give summary for whole infrastructure from date_from (exclusive) to now
+
+        Will give summary for whole infrastructure from
+        date_from (exclusive) to now
         """
         client_token = self._request_to_token(request)
         if client_token is None:

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -25,20 +25,20 @@ class CloudRecordSummaryView(APIView):
     .../api/v1/cloud/record/summary?user=<global_user_name>&from=<date_from>&to=<date_to>
 
     Will return the summary for global_user_name at all services,
-    between date_from and date_to as daily summaries
+    between date_from and date_to (exclusive) as daily summaries
 
     .../api/v1/cloud/record/summary?group=<group_name>&from=<date_from>&to=<date_to>
 
     Will return the summary for group_name at all services,
-    between date_from and date_to as daily summaries
+    between date_from and date_to (exclusive) as daily summaries
 
     .../api/v1/cloud/record/summary?service=<service_name>&from=<date_from>&to=<date_to>
 
     Will return the summary for service_name at all groups,
-    between date_from and date_to as daily summaries
+    between date_from and date_to (exclusive) as daily summaries
 
     .../api/v1/cloud/record/summary?from=<date_from>
-    Will give summary for whole infrastructure from <data> to now
+    Will give summary for whole infrastructure from date_from (exclusive) to now
     """
 
     def __init__(self):
@@ -53,20 +53,20 @@ class CloudRecordSummaryView(APIView):
         .../api/v1/cloud/record/summary?user=<global_user_name>&from=<date_from>&to=<date_to>
 
         Will return the summary for global_user_name at all services,
-        between date_from and date_to as daily summaries
+        between date_from and date_to (exclusive) as daily summaries
 
         .../api/v1/cloud/record/summary?group=<group_name>&from=<date_from>&to=<date_to>
 
         Will return the summary for group_name at all services,
-        between date_from and date_to as daily summaries
+        between date_from and date_to (exclusive) as daily summaries
 
         .../api/v1/cloud/record/summary?service=<service_name>&from=<date_from>&to=<date_to>
 
         Will return the summary for service_name at all groups,
-        between date_from and date_to as daily summaries
+        between date_from and date_to (exclusive) as daily summaries
 
         .../api/v1/cloud/record/summary?from=<date_from>
-        Will give summary for whole infrastructure from <data> to now
+        Will give summary for whole infrastructure from date_from (exclusive) to now
         """
         client_token = self._request_to_token(request)
         if client_token is None:

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -91,11 +91,10 @@ class CloudRecordSummaryView(APIView):
          global_user_name) = self._parse_query_parameters(request)
 
         # Check that at most one of group_name, service_name
-        # and global_user_name is set
+        # and global_user_name is set as having more than
+        # one defined is currently ambiguous while retrieval
+        # against only one parameter per GET request is supported.
         parameters_to_check = (group_name, service_name, global_user_name)
-
-        # for each variable in parameters_to_check that
-        # is not none, increment set_count
         set_count = sum([1 for para in parameters_to_check if para is None])
         if set_count <= 1:
             self.logger.error("User, Group and/or Service combined.")

--- a/doc/user.md
+++ b/doc/user.md
@@ -36,6 +36,8 @@ For Example:
 
 `from` is the only compulsary option, failure to include it will result in a 400 response.
 
+Currently, only one of `user`, `group` or `service` can be set in the same query. Combining more than one will result in a 400 response.
+
 ### Expected Status Codes
 * 200: Your request was succesfully met.
 * 400: No key=value pair provided for from.

--- a/doc/user.md
+++ b/doc/user.md
@@ -40,7 +40,7 @@ Currently, only one of `user`, `group` or `service` can be set in the same query
 
 ### Expected Status Codes
 * 200: Your request was succesfully met.
-* 400: No key=value pair provided for from.
+* 400: No key=value pair provided for `from`, or more than one of `user`, `group` or `service` is set.
 * 401: Your service's OAuth token was not provided by the request, or was not successfully extracted by the server.
 * 403: Your service's OAuth token was extracted by the server, but the IAM does not recognise it.
 * 500: An unknown error has a occured.

--- a/doc/user.md
+++ b/doc/user.md
@@ -30,6 +30,7 @@ For Example:
 
 * `group`: The group within Indigo DataCloud.
 * `service`: The site that provided the resource.
+* `user`: The global user name of the resource submitter.
 * `to`: Display summaries for dates (YYYYMMDD) up until this value, but exclusive of it.
 * `from`: Display summaries for dates (YYYYMMDD) after this value, but exclusive of it.
 
@@ -57,6 +58,7 @@ For Example:
             "SiteName": "Test-Site", 
             "LatestStartTime": "2013-02-25T17:37:27", 
             "EarliestStartTime": "2013-02-25T17:37:27", 
+            "GlobalUserName": "TestDN",
             "Day": 26, 
             "Month": 2
         }, 
@@ -68,6 +70,7 @@ For Example:
             "SiteName": "Test-Site", 
             "LatestStartTime": "2013-02-25T17:37:27", 
             "EarliestStartTime": "2013-02-25T17:37:27", 
+            "GlobalUserName": "TestDN",
             "Day": 27, 
             "Month": 2
         }


### PR DESCRIPTION
As requested by the Indigo SLA/QoS tool (which access the summaries), so that if the Indigo group information does not propagate fully to the provider, the SLA/QoS tool can determine usage per user and assign that to a group via a mapping they can access/maintain.

This PR:
- exposes the field `GlobalUserName` in the returned summaries (by adding it to `RETURN_HEADERS`)
- adds the ability to query the summaries via `GlobalUserName`, 
   i.e. `/api/vi/cloud/summary?user=someuser`
- adds `GlobalUserName` to the expected responses of test cases
- updates user documentation to explain the `user` key=value pair and updated example returned summaries.