### PR TITLE
Upgrade to APEL 1.6.0

### DIFF
--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -302,20 +302,24 @@ class CloudRecordSummaryTest(TestCase):
                        '(VMUUID, SiteID, GlobalUserNameID, VOID, '
                        'VOGroupID, VORoleID, Status, StartTime, '
                        'SuspendDuration, WallDuration, PublisherDNID, '
-                       'CloudType, ImageId) '
+                       'CloudType, ImageId, '
+                       'CloudComputeServiceID) '   
                        'VALUES '
                        '("TEST-VM", 1, 1, 1, 1, 1, "Running", '
-                       '"2016-07-30 00:00:00", 0, 86399, 1, "TEST", "1");')
+                       '"2016-07-30 00:00:00", 0, 86399, 1, "TEST", "1", '
+                       '1);')
 
         # Insert example usage data
         cursor.execute('INSERT INTO CloudRecords '
                        '(VMUUID, SiteID, GlobalUserNameID, VOID, '
                        'VOGroupID, VORoleID, Status, StartTime, '
                        'SuspendDuration, WallDuration, PublisherDNID, '
-                       'CloudType, ImageId) '
+                       'CloudType, ImageId, '
+                       'CloudComputeServiceID) '
                        'VALUES '
                        '("TEST-VM", 1, 1, 1, 1, 1, "Running", '
-                       '"2016-07-30 00:00:00", 0, 129599, 1, "TEST", "1");')
+                       '"2016-07-30 00:00:00", 0, 129599, 1, "TEST", "1", '
+                       '1);')
 
         # These INSERT statements are needed
         # because we query VCloudSummaries
@@ -324,6 +328,7 @@ class CloudRecordSummaryTest(TestCase):
         cursor.execute('INSERT INTO VOGroups VALUES (1, "TestGroup");')
         cursor.execute('INSERT INTO VORoles VALUES (1, "TestRole");')
         cursor.execute('INSERT INTO DNs VALUES (1, "TestDN");')
+        cursor.execute('INSERT INTO CloudComputeServices VALUES (1, "TestService");')
 
         # Summarise example usage data
         cursor.execute('CALL SummariseVMs();')
@@ -352,6 +357,9 @@ class CloudRecordSummaryTest(TestCase):
                        'WHERE id=1;')
 
         cursor.execute('DELETE FROM DNs '
+                       'WHERE id=1;')
+
+        cursor.execute('DELETE FROM CloudComputeServices '
                        'WHERE id=1;')
 
         database.commit()

--- a/api/tests/test_cloud_record_summary.py
+++ b/api/tests/test_cloud_record_summary.py
@@ -303,7 +303,7 @@ class CloudRecordSummaryTest(TestCase):
                        'VOGroupID, VORoleID, Status, StartTime, '
                        'SuspendDuration, WallDuration, PublisherDNID, '
                        'CloudType, ImageId, '
-                       'CloudComputeServiceID) '   
+                       'CloudComputeServiceID) '
                        'VALUES '
                        '("TEST-VM", 1, 1, 1, 1, 1, "Running", '
                        '"2016-07-30 00:00:00", 0, 86399, 1, "TEST", "1", '

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,13 +27,13 @@ gpgkey=http://repository.egi.eu/sw/production/cas/1/GPG-KEY-EUGridPMA-RPM-3' >> 
 RUN yum -y install wget unzip python-pip python-devel mysql mysql-devel gcc httpd httpd-devel mod_wsgi mod_ssl vixie-cron at ca-policy-egi-core python-iso8601 python-ldap fetch-crl
 
 # get APEL codebase
-RUN wget https://github.com/apel/apel/releases/download/1.5.1-1/apel-lib-1.5.1-1.el6.noarch.rpm
-RUN wget https://github.com/apel/apel/releases/download/1.5.1-1/apel-server-1.5.1-1.el6.noarch.rpm
+RUN wget https://github.com/apel/apel/releases/download/1.6.0-1/apel-lib-1.6.0-1.el6.noarch.rpm
+RUN wget https://github.com/apel/apel/releases/download/1.6.0-1/apel-server-1.6.0-1.el6.noarch.rpm
 
 # Install APEL code base
 # use --nodeps because we dont need the ssm
-RUN rpm -i apel-lib-1.5.1-1.el6.noarch.rpm --nodeps
-RUN rpm -i apel-server-1.5.1-1.el6.noarch.rpm --nodeps
+RUN rpm -i apel-lib-1.6.0-1.el6.noarch.rpm --nodeps
+RUN rpm -i apel-server-1.6.0-1.el6.noarch.rpm --nodeps
 
 # get APEL REST interface
 RUN wget https://github.com/indigo-dc/Accounting/archive/1.2.1-1.zip -O apel_rest.zip

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -6,7 +6,7 @@ CREATE TABLE CloudRecords (
 
   VMUUID VARCHAR(255) NOT NULL, 
   SiteID INT NOT NULL,                -- Foreign key
-  CloudComputeServiceID INT,          -- Foreign key
+  CloudComputeServiceID INT NOT NULL, -- Foreign key
 
   MachineName VARCHAR(255), 
 
@@ -96,7 +96,7 @@ CREATE TABLE CloudSummaries (
   UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
   SiteID INT NOT NULL, -- Foreign key
-  CloudComputeServiceID INT, -- Foreign key
+  CloudComputeServiceID INT NOT NULL, -- Foreign key
 
   Day INT NOT NULL,
   Month INT NOT NULL,

--- a/schemas/cloud.sql
+++ b/schemas/cloud.sql
@@ -6,6 +6,7 @@ CREATE TABLE CloudRecords (
 
   VMUUID VARCHAR(255) NOT NULL, 
   SiteID INT NOT NULL,                -- Foreign key
+  CloudComputeServiceID INT,          -- Foreign key
 
   MachineName VARCHAR(255), 
 
@@ -53,7 +54,7 @@ CREATE TABLE CloudRecords (
 DROP PROCEDURE IF EXISTS ReplaceCloudRecord;
 DELIMITER //
 CREATE PROCEDURE ReplaceCloudRecord(
-  VMUUID VARCHAR(255), site VARCHAR(255), 
+  VMUUID VARCHAR(255), site VARCHAR(255), cloudComputeService VARCHAR(255),
   machineName VARCHAR(255), 
   localUserId VARCHAR(255),
   localGroupId VARCHAR(255), globalUserName VARCHAR(255), 
@@ -68,11 +69,11 @@ CREATE PROCEDURE ReplaceCloudRecord(
   imageId VARCHAR(255), cloudType VARCHAR(255),
   publisherDN VARCHAR(255))
 BEGIN
-    REPLACE INTO CloudRecords(VMUUID, SiteID, MachineName, LocalUserId, LocalGroupId,
+    REPLACE INTO CloudRecords(VMUUID, SiteID, CloudComputeServiceID, MachineName, LocalUserId, LocalGroupId,
         GlobalUserNameID, FQAN, VOID, VOGroupID, VORoleID, Status, StartTime, EndTime, SuspendDuration,
         WallDuration, CpuDuration, CpuCount, NetworkType, NetworkInbound, NetworkOutbound, Memory, Disk, StorageRecordId, ImageId, CloudType, PublisherDNID)
       VALUES (
-        VMUUID, SiteLookup(site), machineName, localUserId, localGroupId, DNLookup(globalUserName), 
+        VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName, localUserId, localGroupId, DNLookup(globalUserName), 
         fqan, VOLookup(vo),
         VOGroupLookup(voGroup), VORoleLookup(voRole), status, startTime, endTime, IFNULL(suspendDuration, 0), 
 	IF((wallDuration IS NULL) AND (status = "completed"), endTime - startTime, wallDuration), cpuDuration, cpuCount, networkType, networkInbound, networkOutbound, memory,
@@ -90,6 +91,7 @@ CREATE TABLE CloudSummaries (
   UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 
   SiteID INT NOT NULL, -- Foreign key
+  CloudComputeServiceID INT, -- Foreign key
 
   Day INT NOT NULL,
   Month INT NOT NULL,
@@ -125,7 +127,7 @@ CREATE TABLE CloudSummaries (
 DROP PROCEDURE IF EXISTS ReplaceCloudSummaryRecord;
 DELIMITER //
 CREATE PROCEDURE ReplaceCloudSummaryRecord(
-  site VARCHAR(255), day INT, month INT, year INT, globalUserName VARCHAR(255), 
+  site VARCHAR(255), cloudComputeService VARCHAR(255), day INT, month INT, year INT, globalUserName VARCHAR(255), 
   vo VARCHAR(255), voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
   cloudType VARCHAR(255), imageId VARCHAR(255), 
   earliestStartTime DATETIME, latestStartTime DATETIME, 
@@ -134,10 +136,10 @@ CREATE PROCEDURE ReplaceCloudSummaryRecord(
   disk BIGINT, numberOfVMs BIGINT,
   publisherDN VARCHAR(255))
 BEGIN
-    REPLACE INTO CloudSummaries(SiteID, Day, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
         WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, Memory, Disk, NumberOfVMs,  PublisherDNID)
       VALUES (
-        SiteLookup(site), day, month, year, DNLookup(globalUserName), VOLookup(vo),
+        SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), day, month, year, DNLookup(globalUserName), VOLookup(vo),
         VOGroupLookup(voGroup), VORoleLookup(voRole), status, cloudType, imageId, earliestStartTime, latestStartTime, 
         wallDuration, cpuDuration, networkInbound, networkOutbound, memory,
         disk, numberOfVMs, DNLookup(publisherDN)
@@ -198,7 +200,8 @@ CREATE TEMPORARY TABLE TVMUsagePerDay
 SELECT
 	ThisRecord.VMUUID as VMUUID,
 	ThisRecord.SiteID as SiteID,
-        ThisRecord.Day as Day,
+	ThisRecord.CloudComputeServiceID as CloudComputeServiceID,
+	ThisRecord.Day as Day,
 	ThisRecord.Month as Month,
 	ThisRecord.Year as Year,
 	ThisRecord.GlobalUserNameID as GlobalUserNameID,
@@ -227,10 +230,11 @@ ON 	(ThisRecord.VMUUID = PrevRecord.VMUUID and
 					AND MeasurementTime < ThisRecord.MeasurementTime)
 	);
 
-    REPLACE INTO CloudSummaries(SiteID, Day, Month, Year, GlobalUserNameID, VOID,
-		VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration, NetworkInbound,
-			NetworkOutbound, Memory, Disk, NumberOfVMs, PublisherDNID)
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID,
+        VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration, NetworkInbound,
+        NetworkOutbound, Memory, Disk, NumberOfVMs, PublisherDNID)
     SELECT SiteID,
+    CloudComputeServiceID,
     Day, Month, Year,
     GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
     MIN(StartTime),
@@ -244,7 +248,7 @@ ON 	(ThisRecord.VMUUID = PrevRecord.VMUUID and
     COUNT(*),
     'summariser'
     FROM TVMUsagePerDay
-    GROUP BY SiteID, Day, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId
+    GROUP BY SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId
     ORDER BY NULL;
 END //
 DELIMITER ;
@@ -286,6 +290,32 @@ BEGIN
     SELECT id FROM Sites WHERE name=lookup INTO result;
     IF result IS NULL THEN
         INSERT INTO Sites(name) VALUES (lookup);
+        SET result=LAST_INSERT_ID();
+    END IF;
+RETURN result;
+END //
+DELIMITER ;
+
+
+-- -----------------------------------------------------------------------------
+-- CloudComputeService
+
+CREATE TABLE CloudComputeServices (
+    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY
+ ,  name VARCHAR(255) NOT NULL
+
+ , INDEX(name)
+
+) ;
+
+DROP FUNCTION IF EXISTS CloudComputeServiceLookup;
+DELIMITER //
+CREATE FUNCTION CloudComputeServiceLookup(lookup VARCHAR(255)) RETURNS INTEGER DETERMINISTIC
+BEGIN
+    DECLARE result INTEGER;
+    SELECT id FROM CloudComputeServices WHERE name=lookup INTO result;
+    IF result IS NULL THEN
+        INSERT INTO CloudComputeServices(name) VALUES (lookup);
         SET result=LAST_INSERT_ID();
     END IF;
 RETURN result;
@@ -398,14 +428,15 @@ DELIMITER ;
 -- -----------------------------------------------------------------------------
 -- View on CloudRecords
 CREATE VIEW VCloudRecords AS
-    SELECT UpdateTime, VMUUID, site.name SiteName, MachineName, 
+    SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService, MachineName, 
            LocalUserId, LocalGroupId, userdn.name GlobalUserName, FQAN, vo.name VO, 
            vogroup.name VOGroup, vorole.name VORole,
            Status, StartTime, EndTime,
            SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
            NetworkInbound, NetworkOutbound, Memory, Disk, StorageRecordId, ImageId, CloudType
-    FROM CloudRecords, Sites site, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
+    FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
         SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
         AND GlobalUserNameID = userdn.id
         AND VOID = vo.id
         AND VOGroupID = vogroup.id
@@ -414,26 +445,28 @@ CREATE VIEW VCloudRecords AS
 -- -----------------------------------------------------------------------------
 -- View on CloudRecords
 CREATE VIEW VAnonCloudRecords AS
-    SELECT UpdateTime, VMUUID, site.name SiteName, MachineName,
+    SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService, MachineName,
            LocalUserId, LocalGroupId, GlobalUserNameID, FQAN, vo.name VO,  Status, StartTime, EndTime,
            SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
            NetworkInbound, NetworkOutbound, Memory, Disk, StorageRecordId, ImageId, CloudType
-    FROM CloudRecords, Sites site, DNs userdn, VOs vo WHERE
+    FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo WHERE
         SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
         AND GlobalUserNameID = userdn.id
         AND VOID = vo.id;
         
 -- -----------------------------------------------------------------------------
 -- View on CloudSummaries
 CREATE VIEW VCloudSummaries AS
-    SELECT UpdateTime, site.name SiteName, Day, Month, Year,
+    SELECT UpdateTime, site.name SiteName, cloudComputeService.name CloudComputeService, Day, Month, Year,
            userdn.name GlobalUserName, vo.name VO, 
            vogroup.name VOGroup, vorole.name VORole,
            Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
            WallDuration, CpuDuration, NetworkInbound, NetworkOutbound, Memory, Disk, 
            NumberOfVMs
-    FROM CloudSummaries, Sites site, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
+    FROM CloudSummaries, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
         SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
         AND GlobalUserNameID = userdn.id
         AND VOID = vo.id
         AND VOGroupID = vogroup.id

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -195,30 +195,115 @@ DROP PROCEDURE IF EXISTS SummariseVMs;
 DELIMITER //
 CREATE PROCEDURE SummariseVMs()
 BEGIN
-    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID,
-        VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
-        WallDuration, CpuDuration, CpuCount, NetworkInbound, NetworkOutbound, Memory, Disk,
+CREATE TEMPORARY TABLE TCloudRecordsWithMeasurementTime
+(INDEX index_measurementtime USING BTREE (MeasurementTime))
+SELECT *, TIMESTAMPADD(SECOND, (IFNULL(SuspendDuration, 0) + WallDuration), StartTime) as MeasurementTime FROM CloudRecords;
+
+CREATE TEMPORARY TABLE TGreatestMeasurementTimePerDay
+(INDEX index_greatestmeasurementtime USING BTREE (MaxMT))
+select
+        Year(MeasurementTime) as Year,
+        Month(MeasurementTime) as Month,
+        Day(MeasurementTime) as Day,
+        VMUUID,
+        max(MeasurementTime) as MaxMT
+        from TCloudRecordsWithMeasurementTime
+        group by
+                Year(MeasurementTime),
+                Month(MeasurementTime),
+                Day(MeasurementTime),
+                VMUUID
+;
+DROP TABLE IF EXISTS LastCloudRecordPerDay;
+CREATE TABLE LastCloudRecordPerDay
+(INDEX index_vmuuidyearmonthday USING BTREE (VMUUID, Year, Month, Day))
+SELECT
+        a.*,
+        Year(a.MeasurementTime) as Year,
+        Month(a.MeasurementTime) as Month,
+        Day(a.MeasurementTime) as Day
+        from TCloudRecordsWithMeasurementTime as a
+        left join
+        TGreatestMeasurementTimePerDay as b
+        on (
+                Year(a.MeasurementTime) = b.Year and
+                Month(a.MeasurementTime) = b.Month and
+                Day(a.MeasurementTime) = b.Day and
+                a.VMUUID = b.VMUUID
+        )
+        where a.MeasurementTime = b.MaxMT
+
+        ORDER BY a.VMUUID, Year(a.MeasurementTime), Month(a.MeasurementTime), Day(a.MeasurementTime)
+;
+
+-- Based on discussion here: http://stackoverflow.com/questions/13196190/mysql-subtracting-value-from-previous-row-group-by
+
+CREATE TEMPORARY TABLE TVMUsagePerDay
+(INDEX index_VMUsagePerDay USING BTREE (VMUUID, Day, Month, Year))
+SELECT
+        ThisRecord.VMUUID as VMUUID,
+        ThisRecord.SiteID as SiteID,
+        ThisRecord.CloudComputeServiceID as CloudComputeServiceID,
+        ThisRecord.Day as Day,
+        ThisRecord.Month as Month,
+        ThisRecord.Year as Year,
+        ThisRecord.GlobalUserNameID as GlobalUserNameID,
+        ThisRecord.VOID as VOID,
+        ThisRecord.VOGroupID as VOGroupID,
+        ThisRecord.VORoleID as VORoleID,
+        ThisRecord.Status as Status,
+        ThisRecord.CloudType as CloudType,
+        ThisRecord.ImageId as ImageId,
+        ThisRecord.StartTime as StartTime,
+        COALESCE(ThisRecord.WallDuration - IFNULL(PrevRecord.WallDuration, 0.00)) AS ComputedWallDuration,
+        COALESCE(ThisRecord.CpuDuration - IFNULL(PrevRecord.CpuDuration, 0.00)) AS ComputedCpuDuration,
+        ThisRecord.CpuCount as CpuCount,
+        COALESCE(ThisRecord.NetworkInbound - IFNULL(PrevRecord.NetworkInbound, 0.00)) AS ComputedNetworkInbound,
+        COALESCE(ThisRecord.NetworkOutbound - IFNULL(PrevRecord.NetworkOutbound, 0.00)) AS ComputedNetworkOutbound,
+        ThisRecord.PublicIPCount as PublicIPCount,
+        -- Will Memory change during the course of the VM lifetime? If so, do we report a maximum, or
+        -- average, or something else?
+        -- If it doesn't change:
+        ThisRecord.Memory,
+        ThisRecord.Disk, -- As above: constant or changing?
+        ThisRecord.BenchmarkType as BenchmarkType,
+        ThisRecord.Benchmark as Benchmark
+FROM    LastCloudRecordPerDay as ThisRecord
+LEFT JOIN LastCloudRecordPerDay as PrevRecord
+ON      (ThisRecord.VMUUID = PrevRecord.VMUUID and
+        PrevRecord.MeasurementTime = (SELECT max(MeasurementTime)
+                                        FROM LastCloudRecordPerDay
+                                        WHERE VMUUID = ThisRecord.VMUUID
+                                        AND MeasurementTime < ThisRecord.MeasurementTime)
+        );
+
+REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Day, Month, Year,
+        GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
+        EarliestStartTime, LatestStartTime, WallDuration, CpuDuration, CpuCount,
+        NetworkInbound, NetworkOutbound, Memory, Disk,
         BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
     SELECT SiteID,
-        CloudComputeServiceID,
-        DAY(StartTime) As Day, MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
-        GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
-        MIN(StartTime),
-        MAX(StartTime),
-        SUM(WallDuration),
-        SUM(CpuDuration),
-        CpuCount,
-        SUM(NetworkInbound),
-        SUM(NetworkOutbound),
-        SUM(Memory),
-        SUM(Disk),
-        BenchmarkType,
-        Benchmark,
-        COUNT(*),
-        'summariser'
-    FROM CloudRecords
-    GROUP BY SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID,
-        Status, CloudType, ImageId, CpuCount, BenchmarkType, Benchmark
+    CloudComputeServiceID,
+    Day, Month, Year,
+    GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
+    MIN(StartTime),
+    MAX(StartTime),
+    SUM(ComputedWallDuration),
+    SUM(ComputedCpuDuration),
+    CpuCount,
+    SUM(ComputedNetworkInbound),
+    SUM(ComputedNetworkOutbound),
+    SUM(PublicIPCount),
+    SUM(Memory),
+    SUM(Disk),
+    BenchmarkType,
+    Benchmark,
+    COUNT(*),
+    'summariser'
+    FROM TVMUsagePerDay
+    GROUP BY SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID,
+        VOGroupID, VORoleID, Status, CloudType, ImageId, CpuCount,
+        BenchmarkType, Benchmark
     ORDER BY NULL;
 END //
 DELIMITER ;

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -1,6 +1,11 @@
 -- This script will set any null UpdateTimes to now
 -- and then explicitly set the UpdateTimes of 
--- future rows to update
+-- future rows to update.
+-- Then, this script applies the APEL 1.6
+-- schema upgrade, adding CloudComputeServiceID,
+-- PublicIPCount, BenchmarkType and Benchmark fields
+-- to the records and summaries (PublicIPCount
+-- is currently not added to summaries)
 
 UPDATE CloudRecords SET UpdateTime = CURRENT_TIMESTAMP WHERE UpdateTime IS NULL;
 ALTER TABLE CloudRecords MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
@@ -11,3 +16,209 @@ ALTER TABLE CloudSummaries MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT C
 UPDATE LastUpdated SET UpdateTime = CURRENT_TIMESTAMP WHERE UpdateTime IS NULL;
 ALTER TABLE LastUpdated MODIFY COLUMN UpdateTime TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
 
+-- Create / Update Tables
+
+/* Update CloudRecords
+
+Existing rows get set to the following:
+
+CloudComputeServiceID - set afterwards
+PublicIPCount - null (NULL)
+BenchmarkType - empty VARCHAR ("")
+Benchmark - decimal zero (0.00)
+*/
+ALTER TABLE CloudRecords
+  ADD CloudComputeServiceID INT NOT NULL AFTER SiteID,
+  ADD PublicIPCount INT AFTER NetworkOutbound,
+  ADD BenchmarkType VARCHAR(50) NOT NULL AFTER Disk,
+  ADD Benchmark DECIMAL(10,3) NOT NULL AFTER BenchmarkType;
+
+
+/* Update CloudSummaries
+
+Existing rows get same values as for CloudRecords
+
+PublicIPCount is not currently used in summaries
+*/
+ALTER TABLE CloudSummaries
+  ADD CloudComputeServiceID INT NOT NULL AFTER SiteID,
+  ADD CpuCount INT AFTER CpuDuration,
+  -- ADD PublicIPCount BIGINT AFTER NetworkOutbound,
+  ADD BenchmarkType VARCHAR(50) NOT NULL AFTER Disk,
+  ADD Benchmark DECIMAL(10,3) NOT NULL AFTER BenchmarkType;
+
+
+-- Create CloudComputeServices lookup table
+CREATE TABLE CloudComputeServices (
+    id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    INDEX(name)
+);
+
+-- Insert row for "None" which can be used as a default value
+INSERT INTO CloudComputeServices (id, name) VALUES(1, "None");
+
+-- Update the existing rows in the Cloud tables with a default value
+UPDATE CloudRecords SET CloudComputeServiceID=1;
+
+UPDATE CloudSummaries SET CloudComputeServiceID=1;
+
+
+-- Create Views
+-- View on CloudRecords
+DROP VIEW IF EXISTS VCloudRecords;
+CREATE VIEW VCloudRecords AS
+    SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService, MachineName, 
+           LocalUserId, LocalGroupId, userdn.name GlobalUserName, FQAN, vo.name VO, 
+           vogroup.name VOGroup, vorole.name VORole,
+           Status, StartTime, EndTime,
+           SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark, StorageRecordId, ImageId, CloudType
+    FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
+        SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
+        AND GlobalUserNameID = userdn.id
+        AND VOID = vo.id
+        AND VOGroupID = vogroup.id
+        AND VORoleID = vorole.id;
+
+-- View on CloudRecords
+DROP VIEW IF EXISTS VAnonCloudRecords;
+CREATE VIEW VAnonCloudRecords AS
+    SELECT UpdateTime, VMUUID, site.name SiteName, cloudComputeService.name CloudComputeService,
+           MachineName, LocalUserId, LocalGroupId, GlobalUserNameID, FQAN, vo.name VO,  Status, 
+           StartTime, EndTime, SuspendDuration, WallDuration, CpuDuration, CpuCount, NetworkType,
+           NetworkInbound, NetworkOutbound, PublicIPCount, Memory, Disk, BenchmarkType, Benchmark,
+           StorageRecordId, ImageId, CloudType
+    FROM CloudRecords, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo WHERE
+        SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
+        AND GlobalUserNameID = userdn.id
+        AND VOID = vo.id;
+
+-- View on CloudSummaries
+DROP VIEW IF EXISTS VCloudSummaries;
+CREATE VIEW VCloudSummaries AS
+    SELECT UpdateTime, site.name SiteName, cloudComputeService.name CloudComputeService, Month, Year,
+           userdn.name GlobalUserName, vo.name VO, vogroup.name VOGroup, vorole.name VORole, Status,
+           CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration,
+           CpuCount, NetworkInbound, NetworkOutbound, Memory, Disk, BenchmarkType, Benchmark,  
+           NumberOfVMs
+    FROM CloudSummaries, Sites site, CloudComputeServices cloudComputeService, DNs userdn, VOs vo, VOGroups vogroup, VORoles vorole WHERE
+        SiteID = site.id
+        AND CloudComputeServiceID = cloudComputeService.id
+        AND GlobalUserNameID = userdn.id
+        AND VOID = vo.id
+        AND VOGroupID = vogroup.id
+        AND VORoleID = vorole.id;
+
+
+-- Create / Replace Functions / Procedures
+-- Create CloudComputeServiceLookup
+DROP FUNCTION IF EXISTS CloudComputeServiceLookup;
+DELIMITER //
+CREATE FUNCTION CloudComputeServiceLookup(lookup VARCHAR(255)) RETURNS INTEGER DETERMINISTIC
+BEGIN
+    DECLARE result INTEGER;
+    SELECT id FROM CloudComputeServices WHERE name=lookup INTO result;
+    IF result IS NULL THEN
+        INSERT INTO CloudComputeServices(name) VALUES (lookup);
+        SET result=LAST_INSERT_ID();
+    END IF;
+RETURN result;
+END //
+DELIMITER ;
+
+-- Replace ReplaceCloudRecords
+DROP PROCEDURE IF EXISTS ReplaceCloudRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceCloudRecord(
+  VMUUID VARCHAR(255), site VARCHAR(255), cloudComputeService VARCHAR(255),
+  machineName VARCHAR(255),
+  localUserId VARCHAR(255),
+  localGroupId VARCHAR(255), globalUserName VARCHAR(255), 
+  fqan VARCHAR(255), vo VARCHAR(255),
+  voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
+  startTime DATETIME, endTime DATETIME,
+  suspendDuration INT,
+  wallDuration INT, cpuDuration INT,
+  cpuCount INT, networkType VARCHAR(255),  networkInbound INT,
+  networkOutbound INT, publicIPCount INT, memory INT,
+  disk INT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), storageRecordId VARCHAR(255),
+  imageId VARCHAR(255), cloudType VARCHAR(255),
+  publisherDN VARCHAR(255))
+BEGIN
+    REPLACE INTO CloudRecords(VMUUID, SiteID, CloudComputeServiceID, MachineName, LocalUserId, LocalGroupId,
+        GlobalUserNameID, FQAN, VOID, VOGroupID, VORoleID, Status, StartTime, EndTime, SuspendDuration,
+        WallDuration, CpuDuration, CpuCount, NetworkType, NetworkInbound, NetworkOutbound, PublicIPCount,
+        Memory, Disk, BenchmarkType, Benchmark, StorageRecordId, ImageId, CloudType, PublisherDNID)
+      VALUES (
+        VMUUID, SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), machineName,
+        localUserId, localGroupId, DNLookup(globalUserName), fqan, VOLookup(vo), VOGroupLookup(voGroup),
+        VORoleLookup(voRole), status, startTime, endTime, suspendDuration, 
+        wallDuration, 
+        cpuDuration, cpuCount, networkType, networkInbound, networkOutbound, publicIPCount, memory,
+        disk, benchmarkType, benchmark, storageRecordId, imageId, cloudType, DNLookup(publisherDN)
+        );
+END //
+DELIMITER ;
+
+-- Replace ReplaceCloudSummaryRecords
+DROP PROCEDURE IF EXISTS ReplaceCloudSummaryRecord;
+DELIMITER //
+CREATE PROCEDURE ReplaceCloudSummaryRecord(
+  site VARCHAR(255), cloudComputeService VARCHAR(255), month INT, year INT, globalUserName VARCHAR(255), 
+  vo VARCHAR(255), voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
+  cloudType VARCHAR(255), imageId VARCHAR(255), 
+  earliestStartTime DATETIME, latestStartTime DATETIME, 
+  wallDuration BIGINT, cpuDuration BIGINT, cpuCount INT,
+  networkInbound BIGINT, networkOutbound BIGINT, memory BIGINT,
+  disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), numberOfVMs BIGINT,
+  publisherDN VARCHAR(255))
+BEGIN
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
+        VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
+        WallDuration, CpuDuration, CpuCount, NetworkInbound, NetworkOutbound, Memory, Disk,
+        BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
+      VALUES (
+        SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year,
+        DNLookup(globalUserName), VOLookup(vo), VOGroupLookup(voGroup), VORoleLookup(voRole),
+        status, cloudType, imageId, earliestStartTime, latestStartTime, wallDuration,
+        cpuDuration, cpuCount, networkInbound, networkOutbound, memory, disk, benchmarkType,
+        benchmark, numberOfVMs, DNLookup(publisherDN)
+        );
+END //
+DELIMITER ;
+
+-- Replace SummariesVMs
+DROP PROCEDURE IF EXISTS SummariseVMs;
+DELIMITER //
+CREATE PROCEDURE SummariseVMs()
+BEGIN
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
+        VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
+        WallDuration, CpuDuration, CpuCount, NetworkInbound, NetworkOutbound, Memory, Disk,
+        BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
+    SELECT SiteID,
+        CloudComputeServiceID,
+        MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
+        GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
+        MIN(StartTime),
+        MAX(StartTime),
+        SUM(WallDuration),
+        SUM(CpuDuration),
+        CpuCount,
+        SUM(NetworkInbound),
+        SUM(NetworkOutbound),
+        SUM(Memory),
+        SUM(Disk),
+        BenchmarkType,
+        Benchmark,
+        COUNT(*),
+        'summariser'
+    FROM CloudRecords
+    GROUP BY SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID,
+        Status, CloudType, ImageId, CpuCount, BenchmarkType, Benchmark
+    ORDER BY NULL;
+END //
+DELIMITER ;

--- a/scripts/update_schema.sql
+++ b/scripts/update_schema.sql
@@ -99,7 +99,7 @@ CREATE VIEW VAnonCloudRecords AS
 -- View on CloudSummaries
 DROP VIEW IF EXISTS VCloudSummaries;
 CREATE VIEW VCloudSummaries AS
-    SELECT UpdateTime, site.name SiteName, cloudComputeService.name CloudComputeService, Month, Year,
+    SELECT UpdateTime, site.name SiteName, cloudComputeService.name CloudComputeService, Day, Month, Year,
            userdn.name GlobalUserName, vo.name VO, vogroup.name VOGroup, vorole.name VORole, Status,
            CloudType, ImageId, EarliestStartTime, LatestStartTime, WallDuration, CpuDuration,
            CpuCount, NetworkInbound, NetworkOutbound, Memory, Disk, BenchmarkType, Benchmark,  
@@ -167,7 +167,7 @@ DELIMITER ;
 DROP PROCEDURE IF EXISTS ReplaceCloudSummaryRecord;
 DELIMITER //
 CREATE PROCEDURE ReplaceCloudSummaryRecord(
-  site VARCHAR(255), cloudComputeService VARCHAR(255), month INT, year INT, globalUserName VARCHAR(255), 
+  site VARCHAR(255), cloudComputeService VARCHAR(255), day INT, month INT, year INT, globalUserName VARCHAR(255), 
   vo VARCHAR(255), voGroup VARCHAR(255), voRole VARCHAR(255), status VARCHAR(255),
   cloudType VARCHAR(255), imageId VARCHAR(255), 
   earliestStartTime DATETIME, latestStartTime DATETIME, 
@@ -176,12 +176,12 @@ CREATE PROCEDURE ReplaceCloudSummaryRecord(
   disk BIGINT, benchmarkType VARCHAR(50), benchmark DECIMAL(10,3), numberOfVMs BIGINT,
   publisherDN VARCHAR(255))
 BEGIN
-    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID,
         VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime, 
         WallDuration, CpuDuration, CpuCount, NetworkInbound, NetworkOutbound, Memory, Disk,
         BenchmarkType, Benchmark, NumberOfVMs,  PublisherDNID)
       VALUES (
-        SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), month, year,
+        SiteLookup(site), CloudComputeServiceLookup(cloudComputeService), day, month, year,
         DNLookup(globalUserName), VOLookup(vo), VOGroupLookup(voGroup), VORoleLookup(voRole),
         status, cloudType, imageId, earliestStartTime, latestStartTime, wallDuration,
         cpuDuration, cpuCount, networkInbound, networkOutbound, memory, disk, benchmarkType,
@@ -195,13 +195,13 @@ DROP PROCEDURE IF EXISTS SummariseVMs;
 DELIMITER //
 CREATE PROCEDURE SummariseVMs()
 BEGIN
-    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID,
+    REPLACE INTO CloudSummaries(SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID,
         VOGroupID, VORoleID, Status, CloudType, ImageId, EarliestStartTime, LatestStartTime,
         WallDuration, CpuDuration, CpuCount, NetworkInbound, NetworkOutbound, Memory, Disk,
         BenchmarkType, Benchmark, NumberOfVMs, PublisherDNID)
     SELECT SiteID,
         CloudComputeServiceID,
-        MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
+        DAY(StartTime) As Day, MONTH(StartTime) AS Month, YEAR(StartTime) AS Year,
         GlobalUserNameID, VOID, VOGroupID, VORoleID, Status, CloudType, ImageId,
         MIN(StartTime),
         MAX(StartTime),
@@ -217,7 +217,7 @@ BEGIN
         COUNT(*),
         'summariser'
     FROM CloudRecords
-    GROUP BY SiteID, CloudComputeServiceID, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID,
+    GROUP BY SiteID, CloudComputeServiceID, Day, Month, Year, GlobalUserNameID, VOID, VOGroupID, VORoleID,
         Status, CloudType, ImageId, CpuCount, BenchmarkType, Benchmark
     ORDER BY NULL;
 END //


### PR DESCRIPTION
Allows the APEL REST docker image to support Cloud Usage Record v0.4

- Adds Cloud Usage Record v0.4 fields to the Indigo `cloud.sql` schema
- Adds `CloudComputeServiceID` dummy data a test case that interacts with `VCloudSumaries`.
  As the view now uses `CloudComputeServiceID` to perform the join.
- Uses a modified version of the APEL `update_schema.sql` file to
  upgrade existing instances of APEL REST for Indigo
- `PublicIPCount` has been left in the v0.4 Cloud Summaries, as this is a feature
  Indigo have been pushing for.
- The Dockerfile has been updated to pull in the APEL 1.6.0-1 RPM, and the build tested
- no (non test) python changes required, as the code to handle v0.4 is 
  in the new APEL RPM