### PR TITLE
Replace `json.dumps(data)` with `data`

### DIFF
--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -76,7 +76,7 @@ class Sender(object):
                                                key_file=self._key,
                                                strict=False)
 
-                conn.request(verb, path, json.dumps(data), headers)
+                conn.request(verb, path, data, headers)
 
                 response = conn.getresponse()
 


### PR DESCRIPTION
This was causing messages to have new lines replaced with `\n` and wrapped in `"`. It was thought the json.dumps step was needed, but that is not the case.