### PR TITLE
Split testing of CloudRecordView into two files

### DIFF
--- a/api/tests/__init__.py
+++ b/api/tests/__init__.py
@@ -1,1 +1,92 @@
-"""This file allows test to be imported as a python package."""
+"""
+Copyright (C) 2016 STFC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+@author Greg Corbett
+"""
+__version__ = '1, 4, 0'
+
+# Example output from the provider list on the CMDB
+PROVIDERS = {'total_rows': 735,
+             'offset': 695,
+             'rows': [
+                 {'id': '1',
+                  'key': ['service'],
+                  'value':{
+                      'sitename': 'TEST2',
+                      'provider_id': 'TEST2',
+                      'type': 'cloud'}},
+                 {'id': '2',
+                  'key': ['service'],
+                  'value':{
+                      'sitename': 'TEST',
+                      'provider_id': 'TEST',
+                      'hostname': 'allowed_host.test',
+                      'type': 'cloud'}},
+                 {'id': '3',
+                  'key': ['service'],
+                  'value':{
+                      'sitename': 'TEST',
+                      'provider_id': 'TEST',
+                      'hostname': 'allowed_host2.test',
+                      'type': 'cloud'}}]}
+
+# An example APEL Cloud Message V0.2
+MESSAGE = """APEL-cloud-message: v0.2
+VMUUID: TestVM1 2013-02-25 17:37:27+00:00
+SiteName: CESGA
+MachineName: one-2421
+LocalUserId: 19
+LocalGroupId: 101
+GlobalUserName: NULL
+FQAN: NULL
+Status: completed
+StartTime: 1361813847
+EndTime: 1361813870
+SuspendDuration: NULL
+WallDuration: NULL
+CpuDuration: NULL
+CpuCount: 1
+NetworkType: NULL
+NetworkInbound: 0
+NetworkOutbound: 0
+Memory: 1000
+Disk: NULL
+StorageRecordId: NULL
+ImageId: NULL
+CloudType: OpenNebula
+%%
+VMUUID: TestVM1 2015-06-25 17:37:27+00:00
+SiteName: CESGA
+MachineName: one-2422
+LocalUserId: 13
+LocalGroupId: 131
+GlobalUserName: NULL
+FQAN: NULL
+Status: completed
+StartTime: 1361413847
+EndTime: 1361811870
+SuspendDuration: NULL
+WallDuration: NULL
+CpuDuration: NULL
+CpuCount: 1
+NetworkType: NULL
+NetworkInbound: 0
+NetworkOutbound: 0
+Memory: 1000
+Disk: NULL
+StorageRecordId: NULL
+ImageId: NULL
+CloudType: OpenNebula
+%%"""

--- a/api/tests/test_cloud_record_helper.py
+++ b/api/tests/test_cloud_record_helper.py
@@ -5,6 +5,7 @@ import logging
 from django.test import TestCase
 from mock import Mock
 
+from api.tests import PROVIDERS
 from api.views.CloudRecordView import CloudRecordView
 
 
@@ -67,27 +68,3 @@ class CloudRecordHelperTest(TestCase):
         CloudRecordView._get_provider_list = Mock(return_value={})
         # in which case we should reject all POST requests
         self.assertFalse(test_cloud_view._signer_is_valid(allowed_dn))
-
-PROVIDERS = {'total_rows': 735,
-             'offset': 695,
-             'rows': [
-                 {'id': '1',
-                  'key': ['service'],
-                  'value':{
-                      'sitename': 'TEST2',
-                      'provider_id': 'TEST2',
-                      'type': 'cloud'}},
-                 {'id': '2',
-                  'key': ['service'],
-                  'value':{
-                      'sitename': 'TEST',
-                      'provider_id': 'TEST',
-                      'hostname': 'allowed_host.test',
-                      'type': 'cloud'}},
-                 {'id': '3',
-                  'key': ['service'],
-                  'value':{
-                      'sitename': 'TEST',
-                      'provider_id': 'TEST',
-                      'hostname': 'allowed_host2.test',
-                      'type': 'cloud'}}]}

--- a/api/tests/test_cloud_record_helper.py
+++ b/api/tests/test_cloud_record_helper.py
@@ -1,0 +1,93 @@
+"""This module tests the helper methods of the CloudRecordView class."""
+
+import logging
+
+from django.test import TestCase
+from mock import Mock
+
+from api.views.CloudRecordView import CloudRecordView
+
+
+class CloudRecordHelperTest(TestCase):
+    """Tests the helper methods of the CloudRecordView class."""
+
+    def setUp(self):
+        """Prevent logging from appearing in test output."""
+        logging.disable(logging.CRITICAL)
+
+    def test_signer_is_valid(self):
+        """
+        Test the CloudRecordView._signer_is_valid method.
+
+        That method determines wether a POST request should be allowed or not.
+        """
+        # mock the external call to the CMDB to retrieve the providers
+        # used in the _signer_is_valid method we are testing
+        CloudRecordView._get_provider_list = Mock(return_value=PROVIDERS)
+        test_cloud_view = CloudRecordView()
+
+        # The DN corresponds to a host listed as a provider
+        allowed_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=allowed_host.test"
+
+        # The Host this DN corresponds to will
+        # be explicitly granted POST rights
+        extra_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=special_host.test"
+
+        # The Host this DN corresponds to will
+        # have its POST rights explicitly revoked
+        banned_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=allowed_host2.test"
+
+        # The Host this DN corresponds is unknown to the system,
+        # it should not be granted POST rights
+        unknown_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=mystery_host.test"
+
+        # Grant/Revoke POST fights
+        with self.settings(ALLOWED_TO_POST=[extra_dn],
+                           BANNED_FROM_POST=[banned_dn]):
+
+            # DNs corresponding to hosts listed as a provider should be valid
+            # i.e have POST rights
+            self.assertTrue(test_cloud_view._signer_is_valid(allowed_dn))
+
+            # DNs corresponding to hosts with explicit access should be valid
+            # i.e have POST rights
+            self.assertTrue(test_cloud_view._signer_is_valid(extra_dn))
+
+            # DNs corresponding to banned hosts should be invalid
+            # i.e not have POST rights
+            self.assertFalse(test_cloud_view._signer_is_valid(banned_dn))
+
+            # DNs corresponding to unknonw hosts should be invalid
+            # i.e not have POST rights
+            self.assertFalse(test_cloud_view._signer_is_valid(unknown_dn))
+
+        # mock the external call to the CMDB to retrieve the providers
+        # used in the _signer_is_valid method we are testing
+        # now we are mocking a failure of the CMDB to respond as expected
+        CloudRecordView._get_provider_list = Mock(return_value={})
+        # in which case we should reject all POST requests
+        self.assertFalse(test_cloud_view._signer_is_valid(allowed_dn))
+
+PROVIDERS = {'total_rows': 735,
+             'offset': 695,
+             'rows': [
+                 {'id': '1',
+                  'key': ['service'],
+                  'value':{
+                      'sitename': 'TEST2',
+                      'provider_id': 'TEST2',
+                      'type': 'cloud'}},
+                 {'id': '2',
+                  'key': ['service'],
+                  'value':{
+                      'sitename': 'TEST',
+                      'provider_id': 'TEST',
+                      'hostname': 'allowed_host.test',
+                      'type': 'cloud'}},
+                 {'id': '3',
+                  'key': ['service'],
+                  'value':{
+                      'sitename': 'TEST',
+                      'provider_id': 'TEST',
+                      'hostname': 'allowed_host2.test',
+                      'type': 'cloud'}}]}

--- a/api/tests/test_cloud_record_post.py
+++ b/api/tests/test_cloud_record_post.py
@@ -9,6 +9,7 @@ from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 from mock import Mock
 
+from api.tests import MESSAGE, PROVIDERS
 from api.views.CloudRecordView import CloudRecordView
 
 QPATH_TEST = '/tmp/django-test/'
@@ -167,68 +168,3 @@ class CloudRecordPostTest(TestCase):
 
                 # check saved message content
                 self.assertEqual(message, message_content)
-
-PROVIDERS = {'total_rows': 735,
-             'offset': 695,
-             'rows': [
-                 {'id': '1',
-                  'key': ['service'],
-                  'value':{
-                      'sitename': 'TEST2',
-                      'provider_id': 'TEST2',
-                      'type': 'cloud'}},
-                 {'id': '2',
-                  'key': ['service'],
-                  'value':{
-                      'sitename': 'TEST',
-                      'provider_id': 'TEST',
-                      'hostname': 'allowed_host.test',
-                      'type': 'cloud'}}]}
-
-MESSAGE = """APEL-cloud-message: v0.2
-VMUUID: TestVM1 2013-02-25 17:37:27+00:00
-SiteName: CESGA
-MachineName: one-2421
-LocalUserId: 19
-LocalGroupId: 101
-GlobalUserName: NULL
-FQAN: NULL
-Status: completed
-StartTime: 1361813847
-EndTime: 1361813870
-SuspendDuration: NULL
-WallDuration: NULL
-CpuDuration: NULL
-CpuCount: 1
-NetworkType: NULL
-NetworkInbound: 0
-NetworkOutbound: 0
-Memory: 1000
-Disk: NULL
-StorageRecordId: NULL
-ImageId: NULL
-CloudType: OpenNebula
-%%
-VMUUID: TestVM1 2015-06-25 17:37:27+00:00
-SiteName: CESGA
-MachineName: one-2422
-LocalUserId: 13
-LocalGroupId: 131
-GlobalUserName: NULL
-FQAN: NULL
-Status: completed
-StartTime: 1361413847
-EndTime: 1361811870
-SuspendDuration: NULL
-WallDuration: NULL
-CpuDuration: NULL
-CpuCount: 1
-NetworkType: NULL
-NetworkInbound: 0
-NetworkOutbound: 0
-Memory: 1000
-Disk: NULL
-StorageRecordId: NULL
-ImageId: NULL
-CloudType: OpenNebula
-%%"""

--- a/api/tests/test_cloud_record_post.py
+++ b/api/tests/test_cloud_record_post.py
@@ -8,15 +8,13 @@ import shutil
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 from mock import Mock
-from rest_framework.request import Request
-from rest_framework.test import APIRequestFactory
 
 from api.views.CloudRecordView import CloudRecordView
 
 QPATH_TEST = '/tmp/django-test/'
 
 
-class CloudRecordTest(TestCase):
+class CloudRecordPostTest(TestCase):
     """Tests POST requests to the Cloud Record endpoint."""
 
     def setUp(self):


### PR DESCRIPTION
`test_cloud_record_helper.py` tests the underlying helper methods.
  - this file contains a new test `test_signer_is_valid`, which only tests the `_signer_is_valid`

`test_cloud_record_post.py` tests the overall `post` method by making POST requests
- this file is essentially the old `test_cloud_record.py`

Splitting the two type of test makes the files more manageable/smaller. The additional test may catch cases when a POST request is made, `_signer_is_valid` fails, but the POST request carries on to fail in the way the test was expected, thus not causing a test failure.

I have also moved class variables to the `__init__.py` file, as `PROVIDERS` was now being defined twice in two different classes (and I felt like MESSAGE could also be moved encase future tests want to make use of it.)

