### PR TITLE
Refactor testing of CloudRecordSummaryView

### DIFF
--- a/api/tests/test_cloud_record_summary_get.py
+++ b/api/tests/test_cloud_record_summary_get.py
@@ -7,12 +7,11 @@ from api.views.CloudRecordSummaryView import CloudRecordSummaryView
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 from mock import Mock
-from rest_framework.test import APIRequestFactory
 
 QPATH_TEST = '/tmp/django-test/'
 
 
-class CloudRecordSummaryTest(TestCase):
+class CloudRecordSummaryGetTest(TestCase):
     """Tests GET requests to the Cloud Sumamry Record endpoint."""
 
     def setUp(self):
@@ -167,127 +166,6 @@ class CloudRecordSummaryTest(TestCase):
         finally:
             self._clear_database(database)
             database.close()
-
-    def test_parse_query_parameters(self):
-        """Test the parsing of query parameters."""
-        # test a get with group, summary, start, end and user
-        test_cloud_view = CloudRecordSummaryView()
-        factory = APIRequestFactory()
-        url = ''.join((reverse('CloudRecordSummaryView'),
-                       '?group=Group1',
-                       '&service=Service1',
-                       '&from=FromDate',
-                       '&to=ToDate',
-                       '&user=UserA'))
-
-        request = factory.get(url)
-
-        parsed_responses = test_cloud_view._parse_query_parameters(request)
-        self.assertEqual(parsed_responses,
-                         ("Group1", "Service1", "FromDate",
-                          "ToDate", "UserA"))
-
-        # test a get with just an end date
-        url = ''.join((reverse('CloudRecordSummaryView'),
-                       '?to=ToDate'))
-
-        request = factory.get(url)
-        parsed_responses = test_cloud_view._parse_query_parameters(request)
-        self.assertEqual(parsed_responses,
-                         (None, None, None,
-                          "ToDate", None))
-
-    def test_paginate_result(self):
-        """Test an empty result is paginated correctly."""
-        # test when no page is given.
-        test_cloud_view = CloudRecordSummaryView()
-        content = test_cloud_view._paginate_result(None, [])
-        expected_content = {'count': 0,
-                            'previous': None,
-                            u'results': [],
-                            'next': None}
-
-        self.assertEqual(content, expected_content)
-
-        # test when page number is incorrect/invalid
-        factory = APIRequestFactory()
-
-        # test when page number is not a number
-        url = ''.join((reverse('CloudRecordSummaryView'),
-                       '?page=a'))
-
-        request = factory.get(url)
-        content = test_cloud_view._paginate_result(request, [])
-        self.assertEqual(content, expected_content)
-
-        # test when page number is out of bounds
-        url = ''.join((reverse('CloudRecordSummaryView'),
-                       '?page=9999'))
-
-        request = factory.get(url)
-        content = test_cloud_view._paginate_result(request, [])
-        self.assertEqual(content, expected_content)
-
-    def test_request_to_token(self):
-        """Test a token can be extracted from request."""
-        test_cloud_view = CloudRecordSummaryView()
-        factory = APIRequestFactory()
-        url = ''.join((reverse('CloudRecordSummaryView'),
-                       '?from=FromDate'))
-
-        request = factory.get(url, HTTP_AUTHORIZATION='Bearer ThisIsAToken')
-
-        token = test_cloud_view._request_to_token(request)
-        self.assertEqual(token, 'ThisIsAToken')
-
-    def test_request_to_token_fail(self):
-        """Test the response of a tokenless request."""
-        test_client = Client()
-
-        url = ''.join((reverse('CloudRecordSummaryView'),
-                       '?from=FromDate'))
-
-        response = test_client.get(url)
-
-        self.assertEqual(response.status_code, 401)
-
-    def test_is_client_authorized(self):
-        """Test a example client is authorised."""
-        test_cloud_view = CloudRecordSummaryView()
-        with self.settings(ALLOWED_FOR_GET='IAmAllowed'):
-            self.assertTrue(
-                test_cloud_view._is_client_authorized(
-                    'IAmAllowed'))
-
-    def test_is_client_authorized_fail(self):
-        """Test the failure of un-authorised clients."""
-        test_cloud_view = CloudRecordSummaryView()
-        with self.settings(ALLOWED_FOR_GET='IAmAllowed'):
-            self.assertFalse(
-                test_cloud_view._is_client_authorized(
-                    'IAmNotAllowed'))
-
-    def test_filter_cursor(self):
-        """Test the filtering of a query object based on settings."""
-        test_cloud_view = CloudRecordSummaryView()
-
-        # A list of test summaries.
-        test_data = [{'Day': 30,
-                      'Month': 7,
-                      'Year': 2016,
-                      'SiteName': 'TEST'}]
-
-        cursor = Mock()
-        # Get the mock cursor object return the test_data.
-        cursor.fetchall = Mock(return_value=test_data)
-
-        with self.settings(RETURN_HEADERS=['SiteName', 'Day']):
-            result = test_cloud_view._filter_cursor(cursor)
-
-        expected_result = [{'SiteName': 'TEST',
-                            'Day': 30}]
-
-        self.assertEqual(result, expected_result)
 
     def tearDown(self):
         """Delete any messages under QPATH and re-enable logging.INFO."""

--- a/api/tests/test_cloud_record_summary_get.py
+++ b/api/tests/test_cloud_record_summary_get.py
@@ -31,11 +31,7 @@ class CloudRecordSummaryGetTest(TestCase):
         # Simulates a failure to translate a token to an ID
         CloudRecordSummaryView._token_to_id = Mock(return_value=None)
 
-        with self.settings(ALLOWED_FOR_GET='TestService',
-                           RETURN_HEADERS=["WallDuration",
-                                           "Day",
-                                           "Month",
-                                           "Year"]):
+        with self.settings(ALLOWED_FOR_GET='TestService'):
             # Make (and check) the GET request
             self._check_summary_get(401,
                                     options=("?group=TestGroup"
@@ -49,12 +45,7 @@ class CloudRecordSummaryGetTest(TestCase):
         # Used in the underlying GET method
         CloudRecordSummaryView._token_to_id = Mock(return_value="TestService")
 
-        with self.settings(ALLOWED_FOR_GET='TestService',
-                           RETURN_HEADERS=["WallDuration",
-                                           "Day",
-                                           "Month",
-                                           "Year"]):
-
+        with self.settings(ALLOWED_FOR_GET='TestService'):
             # Make (and check) the GET request
             self._check_summary_get(400, options="?group=TestGroup",
                                     authZ_header_cont="Bearer TestToken")
@@ -66,11 +57,7 @@ class CloudRecordSummaryGetTest(TestCase):
         # Used in the underlying GET method
         CloudRecordSummaryView._token_to_id = Mock(return_value="FakeService")
 
-        with self.settings(ALLOWED_FOR_GET='TestService',
-                           RETURN_HEADERS=["WallDuration",
-                                           "Day",
-                                           "Month",
-                                           "Year"]):
+        with self.settings(ALLOWED_FOR_GET='TestService'):
             # Make (and check) the GET request
             self._check_summary_get(403,
                                     options=("?group=TestGroup"

--- a/api/tests/test_cloud_record_summary_get.py
+++ b/api/tests/test_cloud_record_summary_get.py
@@ -133,13 +133,13 @@ class CloudRecordSummaryGetTest(TestCase):
         # Form the URL to make the GET request to
         url = ''.join((reverse('CloudRecordSummaryView'), options))
 
-        # If content for a HTTP_AUTHORIZATION has been provided,
-        # make the GET request with the appropriate header
         if authZ_header_cont is not None:
+            # If content for a HTTP_AUTHORIZATION has been provided,
+            # make the GET request with the appropriate header
             response = test_client.get(url,
                                        HTTP_AUTHORIZATION=authZ_header_cont)
-        # Otherise, make a GET request without a HTTP_AUTHORIZATION header
         else:
+            # Otherise, make a GET request without a HTTP_AUTHORIZATION header
             response = test_client.get(url)
 
         # Check the expected response code has been received.

--- a/api/tests/test_cloud_record_summary_helper.py
+++ b/api/tests/test_cloud_record_summary_helper.py
@@ -1,11 +1,10 @@
 """This module tests the helper methods of the CloudRecordView class."""
 
 import logging
-import MySQLdb
 
 from api.views.CloudRecordSummaryView import CloudRecordSummaryView
 from django.core.urlresolvers import reverse
-from django.test import Client, TestCase
+from django.test import TestCase
 from mock import Mock
 from rest_framework.test import APIRequestFactory
 
@@ -92,21 +91,22 @@ class CloudRecordSummaryHelperTest(TestCase):
         url = ''.join((reverse('CloudRecordSummaryView'),
                        '?from=FromDate'))
 
+        # Test we can extract the token from a
+        # normaly structured Authorization header
         request = factory.get(url, HTTP_AUTHORIZATION='Bearer ThisIsAToken')
-
         token = test_cloud_view._request_to_token(request)
         self.assertEqual(token, 'ThisIsAToken')
 
-    def test_request_to_token_fail(self):
-        """Test the response of a tokenless request."""
-        test_client = Client()
+        # Test we return None when failing to extract the token
+        # from a malformed Authorization header
+        request = factory.get(url, HTTP_AUTHORIZATION='ThisIsAToken')
+        token = test_cloud_view._request_to_token(request)
+        self.assertEqual(token, None)
 
-        url = ''.join((reverse('CloudRecordSummaryView'),
-                       '?from=FromDate'))
-
-        response = test_client.get(url)
-
-        self.assertEqual(response.status_code, 401)
+        # Test we return None when no token provided
+        request = factory.get(url)
+        token = test_cloud_view._request_to_token(request)
+        self.assertEqual(token, None)
 
     def test_is_client_authorized(self):
         """Test a example client is authorised."""

--- a/api/tests/test_cloud_record_summary_helper.py
+++ b/api/tests/test_cloud_record_summary_helper.py
@@ -1,0 +1,151 @@
+"""This module tests the helper methods of the CloudRecordView class."""
+
+import logging
+import MySQLdb
+
+from api.views.CloudRecordSummaryView import CloudRecordSummaryView
+from django.core.urlresolvers import reverse
+from django.test import Client, TestCase
+from mock import Mock
+from rest_framework.test import APIRequestFactory
+
+QPATH_TEST = '/tmp/django-test/'
+
+
+class CloudRecordSummaryHelperTest(TestCase):
+    """
+    Tests the helper methods of the CloudRecordSummaryView class.
+
+    Some of these do make GET Request objects, as the helper methods
+    expect take the whole request as input, they do not call
+    CloudRecordSummaryView.get() however.
+    """
+
+    def setUp(self):
+        """Prevent logging from appearing in test output."""
+        logging.disable(logging.CRITICAL)
+
+    def test_parse_query_parameters(self):
+        """Test the parsing of query parameters."""
+        # test a get with group, summary, start, end and user
+        test_cloud_view = CloudRecordSummaryView()
+        factory = APIRequestFactory()
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?group=Group1',
+                       '&service=Service1',
+                       '&from=FromDate',
+                       '&to=ToDate',
+                       '&user=UserA'))
+
+        request = factory.get(url)
+
+        parsed_responses = test_cloud_view._parse_query_parameters(request)
+        self.assertEqual(parsed_responses,
+                         ("Group1", "Service1", "FromDate",
+                          "ToDate", "UserA"))
+
+        # test a get with just an end date
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?to=ToDate'))
+
+        request = factory.get(url)
+        parsed_responses = test_cloud_view._parse_query_parameters(request)
+        self.assertEqual(parsed_responses,
+                         (None, None, None,
+                          "ToDate", None))
+
+    def test_paginate_result(self):
+        """Test an empty result is paginated correctly."""
+        # test when no page is given.
+        test_cloud_view = CloudRecordSummaryView()
+        content = test_cloud_view._paginate_result(None, [])
+        expected_content = {'count': 0,
+                            'previous': None,
+                            u'results': [],
+                            'next': None}
+
+        self.assertEqual(content, expected_content)
+
+        # test when page number is incorrect/invalid
+        factory = APIRequestFactory()
+
+        # test when page number is not a number
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?page=a'))
+
+        request = factory.get(url)
+        content = test_cloud_view._paginate_result(request, [])
+        self.assertEqual(content, expected_content)
+
+        # test when page number is out of bounds
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?page=9999'))
+
+        request = factory.get(url)
+        content = test_cloud_view._paginate_result(request, [])
+        self.assertEqual(content, expected_content)
+
+    def test_request_to_token(self):
+        """Test a token can be extracted from request."""
+        test_cloud_view = CloudRecordSummaryView()
+        factory = APIRequestFactory()
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?from=FromDate'))
+
+        request = factory.get(url, HTTP_AUTHORIZATION='Bearer ThisIsAToken')
+
+        token = test_cloud_view._request_to_token(request)
+        self.assertEqual(token, 'ThisIsAToken')
+
+    def test_request_to_token_fail(self):
+        """Test the response of a tokenless request."""
+        test_client = Client()
+
+        url = ''.join((reverse('CloudRecordSummaryView'),
+                       '?from=FromDate'))
+
+        response = test_client.get(url)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_is_client_authorized(self):
+        """Test a example client is authorised."""
+        test_cloud_view = CloudRecordSummaryView()
+        with self.settings(ALLOWED_FOR_GET='IAmAllowed'):
+            self.assertTrue(
+                test_cloud_view._is_client_authorized(
+                    'IAmAllowed'))
+
+    def test_is_client_authorized_fail(self):
+        """Test the failure of un-authorised clients."""
+        test_cloud_view = CloudRecordSummaryView()
+        with self.settings(ALLOWED_FOR_GET='IAmAllowed'):
+            self.assertFalse(
+                test_cloud_view._is_client_authorized(
+                    'IAmNotAllowed'))
+
+    def test_filter_cursor(self):
+        """Test the filtering of a query object based on settings."""
+        test_cloud_view = CloudRecordSummaryView()
+
+        # A list of test summaries.
+        test_data = [{'Day': 30,
+                      'Month': 7,
+                      'Year': 2016,
+                      'SiteName': 'TEST'}]
+
+        cursor = Mock()
+        # Get the mock cursor object return the test_data.
+        cursor.fetchall = Mock(return_value=test_data)
+
+        with self.settings(RETURN_HEADERS=['SiteName', 'Day']):
+            result = test_cloud_view._filter_cursor(cursor)
+
+        expected_result = [{'SiteName': 'TEST',
+                            'Day': 30}]
+
+        self.assertEqual(result, expected_result)
+
+    def tearDown(self):
+        """Delete any messages under QPATH and re-enable logging.INFO."""
+        logging.disable(logging.NOTSET)


### PR DESCRIPTION
Split test_cloud_record_summary.py into two files. 
- Tests in `api/tests/test_cloud_record_summary_get.py`  make `GET` requests and looks at the response for test pass/fail.
- Tests in `api/tests/test_cloud_record_summary_helper.py` test helper methods and looks at the result of those methods to determine test pass/fail (note: some of these do make GET request objects, as the helper methods expect take the whole request as input, but don't actually make GET requests )

Remove test_request_to_token_fail
- The functionality of making a GET request with a malformed/missing AuthN header is already tested in `api/tests/test_cloud_record_summary_get.py`. 
- New functionality has been added to test_request_to_token to unit test the underlying method

Adds a helper method to make GET  requests

Remove unnecessary `with` statements