### PR TITLE
Add Token introspection and Caching

### DIFF
--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -163,7 +163,8 @@ SECRET_KEY = 'not_a_secure_secret'
 
 PROVIDERS_URL = 'provider_url'
 
-IAM_URL = 'iam_url'
+# The Hostnames of IAMs that can issue access tokens for the REST interface
+IAM_HOSTNAME_LIST = ['allowed_iams']
 SERVER_IAM_ID = 'server_iam_id'
 SERVER_IAM_SECRET = 'server_iam_secret'
 

--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -163,7 +163,7 @@ SECRET_KEY = 'not_a_secure_secret'
 
 PROVIDERS_URL = 'provider_url'
 
-# The Hostnames of IAMs that can issue access tokens for the REST interface
+# List of hostnames of IAMs that can issue access tokens for the REST interface
 IAM_HOSTNAME_LIST = ['allowed_iams']
 SERVER_IAM_ID = 'server_iam_id'
 SERVER_IAM_SECRET = 'server_iam_secret'

--- a/api/tests/test_cloud_record_summary_get.py
+++ b/api/tests/test_cloud_record_summary_get.py
@@ -54,6 +54,7 @@ class CloudRecordSummaryGetTest(TestCase):
 
     @patch.object(TokenChecker, 'valid_token_to_id')
     def test_cloud_record_summary_get_403(self, mock_valid_token_to_id):
+        """Test an unauthorized service cannot make a GET request."""
         # Mock the functionality of the IAM
         # Simulates the translation of a token to an unauthorized ID
         # Used in the underlying GET method

--- a/api/tests/test_cloud_record_summary_get.py
+++ b/api/tests/test_cloud_record_summary_get.py
@@ -4,9 +4,10 @@ import logging
 import MySQLdb
 
 from api.views.CloudRecordSummaryView import CloudRecordSummaryView
+from api.utils.TokenChecker import TokenChecker
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
-from mock import Mock
+from mock import Mock, patch
 
 QPATH_TEST = '/tmp/django-test/'
 
@@ -18,7 +19,8 @@ class CloudRecordSummaryGetTest(TestCase):
         """Prevent logging from appearing in test output."""
         logging.disable(logging.CRITICAL)
 
-    def test_cloud_record_summary_get_IAM_fail(self):
+    @patch.object(TokenChecker, 'valid_token_to_id')
+    def test_cloud_record_summary_get_IAM_fail(self, mock_valid_token_to_id):
         """
         Test what happens if we fail to contact the IAM.
 
@@ -29,7 +31,7 @@ class CloudRecordSummaryGetTest(TestCase):
         # Mock the functionality of the IAM
         # Used in the underlying GET method
         # Simulates a failure to translate a token to an ID
-        CloudRecordSummaryView._token_to_id = Mock(return_value=None)
+        mock_valid_token_to_id.return_value = None
 
         with self.settings(ALLOWED_FOR_GET='TestService'):
             # Make (and check) the GET request
@@ -38,24 +40,25 @@ class CloudRecordSummaryGetTest(TestCase):
                                              "&from=20000101&to=20191231"),
                                     authZ_header_cont="Bearer TestToken")
 
-    def test_cloud_record_summary_get_400(self):
+    @patch.object(TokenChecker, 'valid_token_to_id')
+    def test_cloud_record_summary_get_400(self, mock_valid_token_to_id):
         """Test a GET request without the from field."""
         # Mock the functionality of the IAM
         # Simulates the translation of a token to an ID
         # Used in the underlying GET method
-        CloudRecordSummaryView._token_to_id = Mock(return_value="TestService")
+        mock_valid_token_to_id.return_value = 'TestService'
 
         with self.settings(ALLOWED_FOR_GET='TestService'):
             # Make (and check) the GET request
             self._check_summary_get(400, options="?group=TestGroup",
                                     authZ_header_cont="Bearer TestToken")
 
-    def test_cloud_record_summary_get_403(self):
-        """Test an unauthorized GET request."""
+    @patch.object(TokenChecker, 'valid_token_to_id')
+    def test_cloud_record_summary_get_403(self, mock_valid_token_to_id):
         # Mock the functionality of the IAM
         # Simulates the translation of a token to an unauthorized ID
         # Used in the underlying GET method
-        CloudRecordSummaryView._token_to_id = Mock(return_value="FakeService")
+        mock_valid_token_to_id.return_value = 'FakeService'
 
         with self.settings(ALLOWED_FOR_GET='TestService'):
             # Make (and check) the GET request
@@ -79,7 +82,8 @@ class CloudRecordSummaryGetTest(TestCase):
                                          "&from=20000101&to=20191231"),
                                 authZ_header_cont="TestToken")
 
-    def test_cloud_record_summary_get_200(self):
+    @patch.object(TokenChecker, 'valid_token_to_id')
+    def test_cloud_record_summary_get_200(self, mock_valid_token_to_id):
         """Test a successful GET request."""
         # Connect to database
         database = self._connect_to_database()
@@ -89,7 +93,7 @@ class CloudRecordSummaryGetTest(TestCase):
         self._populate_database(database)
 
         # Mock the functionality of the IAM
-        CloudRecordSummaryView._token_to_id = Mock(return_value="TestService")
+        mock_valid_token_to_id.return_value = 'TestService'
 
         expected_response = ('{'
                              '"count":2,'

--- a/api/tests/test_cloud_record_summary_get.py
+++ b/api/tests/test_cloud_record_summary_get.py
@@ -3,11 +3,10 @@
 import logging
 import MySQLdb
 
-from api.views.CloudRecordSummaryView import CloudRecordSummaryView
 from api.utils.TokenChecker import TokenChecker
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
-from mock import Mock, patch
+from mock import patch
 
 QPATH_TEST = '/tmp/django-test/'
 

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -5,22 +5,131 @@ import unittest
 import time
 
 from jose import jwt
+from django.test import TestCase
+from mock import patch
 
 from api.utils.TokenChecker import TokenChecker
 
 
 # Using unittest and not django.test as no need for overhead of database
-class TokenCheckerTest(unittest.TestCase):
+class TokenCheckerTest(TestCase):
     """Tests the JSON Web Token validation."""
 
     def setUp(self):
         """Create a new TokenChecker and disable logging."""
-        self._token_checker = TokenChecker()
+        self._token_checker = TokenChecker(None, None)
         logging.disable(logging.CRITICAL)
 
     def tearDown(self):
         """Re-enable logging."""
         logging.disable(logging.NOTSET)
+
+    @patch.object(TokenChecker, '_get_issuer_public_key')
+    def test_valid_token(self, mock_get_issuer_public_key):
+        """Check a valid and properly signed token is accepted."""
+        # Mock the external call to retrieve the IAM public key
+        # used in the _verify_token and is_token_valid call
+        mock_get_issuer_public_key.return_value = PUBLIC_KEY
+
+        payload_list = []
+
+        # This payload will be valid as we will sign it with PRIVATE_KEY
+        payload = {
+            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'iat': int(time.time()) - 2000000,
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
+            'exp': int(time.time()) + 200000}
+
+        token = self._create_token(payload, PRIVATE_KEY)
+
+        with self.settings(IAM_HOSTNAME_LIST='iam-test.indigo-datacloud.eu'):
+            self.assertTrue(
+                self._token_checker.is_token_valid(token),
+                "Token with payload %s should be accepted!" % payload)
+
+    @patch.object(TokenChecker, '_get_issuer_public_key')
+    def test_verify_token(self, mock_get_issuer_public_key):
+        """
+        Check a mis-signed/'forged' token is detected.
+
+        Both by:
+         - _verify_token
+         - is_token_valid
+
+        The first method checks wether the key is properly signed
+        The second method detemines wether the token is invalid
+        """
+        # Mock the external call to retrieve the IAM public key
+        # used in the _verify_token and is_token_valid call
+        mock_get_issuer_public_key.return_value = PUBLIC_KEY
+
+        payload_list = []
+
+        # This payload would be valid if properly signed, but we are going to
+        # sign it with FORGED_PRIVATE_KEY which will not match the PUBLIC_KEY
+        payload_list.append({
+            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'iat': int(time.time()) - 2000000,
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
+            'exp': int(time.time()) + 200000})
+
+        for payload in payload_list:
+            token = self._create_token(payload, FORGED_PRIVATE_KEY)
+            with self.settings(IAM_HOSTNAME_LIST='iam-test.indigo-datacloud.eu'):
+                self.assertFalse(
+                    self._token_checker._verify_token(token, payload['iss']),
+                    "Payload %s should not be accepted!" % payload)
+
+                self.assertFalse(
+                    self._token_checker.is_token_valid(token),
+                    "Token with payload %s should not be accepted!" % payload)
+
+    def test_is_token_issuer_trusted(self):
+        """
+        Check an untrusted 'issuer' (or missing 'issuer') is detected.
+
+        Both by:
+         - _is_token_issuer_trusted
+         - is_token_valid
+
+        The first method checks wether the issuer is
+        in settings.IAM_HOSTNAME_LIST
+        The second method detemines wether the token is invalid
+        """
+        payload_list = []
+
+        # Add a payload without 'iss' field.
+        # to test we reject these as we cannot
+        # tell where it came from (so can't verify it)
+        payload_list.append({
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'iat': int(time.time()) - 2000000,
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
+            'exp': int(time.time()) + 200000})
+
+        # Add a payload with a malicious 'iss' field.
+        # to test we reject these as we do not wantt
+        # to attempt to verify it
+        payload_list.append({
+            'iss': 'https://malicious-iam.indigo-datacloud.biz/',
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'iat': int(time.time()) - 2000000,
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
+            'exp': int(time.time()) + 200000})
+
+        for payload in payload_list:
+            token = self._create_token(payload, PRIVATE_KEY)
+
+            with self.settings(IAM_HOSTNAME_LIST='iam-test.indigo-datacloud.eu'):
+                self.assertFalse(
+                    self._token_checker._is_token_issuer_trusted(payload),
+                    "Payload %s should not be accepted!" % payload)
+
+                self.assertFalse(
+                    self._token_checker.is_token_valid(token),
+                    "Token with payload %s should not be accepted!" % payload)
 
     def test_is_token_json_temporally_valid(self):
         """
@@ -97,6 +206,7 @@ class TokenCheckerTest(unittest.TestCase):
         """Return a token, signed by key, correspond to the payload."""
         return jwt.encode(payload, key, algorithm='RS256')
 
+# Used to sign tokens
 PRIVATE_KEY = """-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAqxAx1H7MabcEYhis3SJoaA3tq6wUgzKzv4c16nAW4yT21P8O
 lL9qKYkzWuJWWiI90ecEHONEjDI+dFfaj/bK2O0jDT1NqVZbn2kW3sXaqUs4lUIg
@@ -124,3 +234,47 @@ UiArAoGBALrLwrhYtwOhMoJPK+XlMTJpLFSOUiGcFg06cvDtsUCz1H0Ma1TuHNSJ
 /El54J1bGpJ/h212wB+gAHE7nRNJfFn5vPJtqwMv/SW675SA4mlKi2xoBO1NW/sw
 FIusZ178P2e/lc+1QJoKkrM7ZKxnDvNj2Lt3B3JmXunXWZpn4i8Q
 -----END RSA PRIVATE KEY-----"""
+
+# Used to verify tokens signed with PRIVATE_KEY
+PUBLIC_KEY = {"keys": [{"kty": "RSA",
+                        "n": ("qxAx1H7MabcEYhis3SJoaA3tq6wUgzKzv4c"
+                              "16nAW4yT21P8OlL9qKYkzWuJWWiI90ecEHO"
+                              "NEjDI-dFfaj_bK2O0jDT1NqVZbn2kW3sXaq"
+                              "Us4lUIg5iPXysknitQjQsO1AmLZXFMNSPCK"
+                              "hBpMPxqG9vBMSxVMIXxXMZXeFpFIOqHFXgt"
+                              "q-KmktwB2Aj_91NlSSj-Lw7bVSaZZNok_ku"
+                              "N_q43A6LS9uRHCQy9aeU0G8rZoqFSfF6Lyp"
+                              "FBN8iZxaw8zlUKy2NYpu6opNUMhTxP7JmEy"
+                              "6yr4kMY7LUNRAKoP4tpgwwgthnecyprGGr9"
+                              "3vh2qifP-bV3J3oa-ub1-jql63Q"),
+                        "e": "Iw"}]}
+
+# Used to 'forge' a token that PUBLIC_KEY will not be able to verify
+FORGED_PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCxHCAbJMUth6NV
+5dz3J6p13NY0deuhST4ped3ogFHvfMlj0ehJMxLVe/B5oooyQkaSyA0yc4eBfYxj
+W4tmOGyWZic1wLhQUQpXvdVcmt+f26GewnIvWOI4MSg1C+Qg9E4I/eIlpz0jrkbq
+q8k/x4pr/c+X8TNiaiZb2Sjp/SFdpwqZ4Eh8u3PPc/B5/mJfvg0T8mrjZ8kQkPcB
+SH+JzbzyFuEpa1OqAWeSOaQniyS2SEdW8DT0/AlQcf3UmvR0Dh5N6KltwWdWdocg
+1jsLCYa32/8uiBJ3JM/C+vWtBjFGGoHp4msk9VAUnq9oWA5z5NT7G1lpoAj1Hjuu
+MnRM9cGnAgMBAAECggEBAIXzrri428TuxHNwMepgfsU77GqrETbgLXqzKEnz24SV
+TcAIf3X1gfYjEiL88ybGB5h2Y7zXshIXAboX/9ulK0OpKVi3VO+yC2+HLTsoC6Bd
+PeTUTgZPZHF5hF5yiuz9uZOFaahuz4gQBKTynnh1k9TPl1Xk4Kc7f52SJiarA7RP
+In7R/YDW6Wxg8fCID1L2McFxlAdHF94oG1qNe1AriaUKZ9MUKaGxmdxuAk3pA1cC
+IqTQYHb1zgJ8oFlhqYVubTL/85ADVV1aY0/UKZcwL1xLJ2xifGvbYPUs5gMJ0w0F
+zHNdhZ6991/F4Txr9Q3kwZX8uwxFFgWSh2qE2aJno8ECgYEA5OLDb3G6zIpbmAU8
+LbfWt/PgsQAa0XtnCrzyz5SnBjPqbesPrg6VxPVdP2/OW+yBvtxmgo3M5xC7LV8C
+x1/In90FXa2KfSXj2OENR/ks55BVdKcI+Jmljmum8AkPvdwb42ztpKgSC8BhItKd
+G5Ft1B2t6EJZY2SPL8UbUXtAkgcCgYEAxhcx2zPlC+x7Y0oKidZswR3M2iB56One
+3dFabzWRA+P7/YA1VM+VPppSDr8AqGpiv0rLh7xK0R6usjmZ1Z/X4oQDF5uiH0uK
+DqsXDF61fFjKClfY4WcUzlcolJ8AD9q50o7bc+hc2WEWxbh/iqfzEWYIa3Y+cuUz
+XMOZJux+62ECgYBTFREV6fWBe5OF2hifC8VQHqFn/n69nYqoti95NB9wu/WTkqit
+aLPqu5nuhfolGfN6wWwgZbKECWm4LW3Hyzf693KUL4M+rDtJpV95ybQIFjc+0ccK
+3lLfIKqHJPLm2vfwlMCqbSunwlxAFK1crWxte5x921+xGXZ0Q5sH97JXjwKBgEGa
+HODDZu9z+ckAFE1hvdKW0+jJKJaCHVTIqHJ8AvKO5j0l4IOd24dIBDTt/IHJ+bnw
+Q0dIjF6FEsXjXZbpwM07euqumBpVIfuJnbBzDReJMCAMx76eLL3JD59oqNSXU0Lw
+HK1eHqG/DZOdbl+1D0KLz+4G0teqIEBwZqAFYmMBAoGBANmBGtkC6APqRe5Dzz9F
+z5L9Mt9Krz8EI6s43XA4fYhouw07zGY0816BGa7r772duZkfh/J8kuxWRdvseo5G
+y3EDz4+nl+tzxzYvbsSNOK8ceJRHNwJQPZuq166svKGLe6tj65MtfvIUTzWUU9FW
+OLxDCvBa2CgAJVfUO1MhtX/L
+-----END PRIVATE KEY-----"""

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -1,0 +1,126 @@
+"""This module tests the JSON Web Token validation."""
+
+import logging
+import unittest
+import time
+
+from jose import jwt
+
+from api.utils.TokenChecker import TokenChecker
+
+
+# Using unittest and not django.test as no need for overhead of database
+class TokenCheckerTest(unittest.TestCase):
+    """Tests the JSON Web Token validation."""
+
+    def setUp(self):
+        """Create a new TokenChecker and disable logging."""
+        self._token_checker = TokenChecker()
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        """Re-enable logging."""
+        logging.disable(logging.NOTSET)
+
+    def test_is_token_json_temporally_valid(self):
+        """
+        Check that temporally invalid payload/token is detected.
+
+        Both by:
+         - _is_token_json_temporally_valid
+         - is_token_valid
+
+        The first method checks the temporal validity of the payload
+        The second method detemines wether the token is invalid
+        """
+        payload_list = []
+
+        # Add a payload wihtout 'iat' or 'exp' to the payload list
+        # to test we reject these (as we are choosing to)
+        payload_list.append({
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
+            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'jti': '714892f5-014f-43ad-bea0-fa47579db222'})
+
+        # Add a payload without 'exp' to the payload_list
+        # to test we reject these (as we are choosing to)
+        payload_list.append({
+            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'iat': int(time.time()) - 2000000,
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36'})
+
+        # Add a payload without 'iat'
+        # to test we reject these (as we are choosing to)
+        payload_list.append({
+            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
+            'exp': int(time.time()) + 200000})
+
+        # Add a payload with an 'iat' and 'exp' in the past
+        # (e.g. they have expired) to test we are
+        # rejecting these
+        payload_list.append({
+            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'iat': int(time.time()) - 2000000,
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
+            'exp': int(time.time()) - 200000})
+
+        # Add a payload with an 'iat' and 'exp' in the future
+        # to test we are rejecting these (as we should as they
+        # are not yet valid)
+        payload_list.append({
+            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'iat': int(time.time()) + 200000,
+            'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
+            'exp': int(time.time()) + 2000000})
+
+        for payload in payload_list:
+            # Assert the underlying helper method reponsible for
+            # checking temporal validity returns False when passed
+            # temporally invalid payloads
+            self.assertFalse(
+                self._token_checker._is_token_json_temporally_valid(payload),
+                "Payload %s should not be accepted!" % payload)
+
+            # Assert the wrapper method is_token_valid reutrns
+            # False when passed temporally invalid tokens
+            token = self._create_token(payload, PRIVATE_KEY)
+            self.assertFalse(
+                self._token_checker.is_token_valid(token),
+                "Token with payload %s should not be accepted!" % payload)
+
+    def _create_token(self, payload, key):
+        """Return a token, signed by key, correspond to the payload."""
+        return jwt.encode(payload, key, algorithm='RS256')
+
+PRIVATE_KEY = """-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAqxAx1H7MabcEYhis3SJoaA3tq6wUgzKzv4c16nAW4yT21P8O
+lL9qKYkzWuJWWiI90ecEHONEjDI+dFfaj/bK2O0jDT1NqVZbn2kW3sXaqUs4lUIg
+5iPXysknitQjQsO1AmLZXFMNSPCKhBpMPxqG9vBMSxVMIXxXMZXeFpFIOqHFXgtq
++KmktwB2Aj/91NlSSj+Lw7bVSaZZNok/kuN/q43A6LS9uRHCQy9aeU0G8rZoqFSf
+F6LypFBN8iZxaw8zlUKy2NYpu6opNUMhTxP7JmEy6yr4kMY7LUNRAKoP4tpgwwgt
+hnecyprGGr93vh2qifP+bV3J3oa+ub1+jql63QIBIwKCAQAJxmk/V7PoyKEqLUu0
+3WUNQp/d7JN1NhjmX39se28Fqlc/XwglwcuNWEwT0mtVm46BBeL6ViEslSgj58NY
+rwRG6PqwTKVaIjEfDVHDlkcCXBHcpLFsPI/89Y07IhCkurni4RO8IgDCVuNYAYCz
+JhZXQO5qsMKFkhOcbva/dgQgm2+yX6i1lFYNstpdr8ODBhiT6Tn7B5CONbLICJFd
+7SdVAORFgdOvRLHkLPcL4I6x0hautCvEf2x47kRaLGtPMsFJQSZYl+Z81whwrJTM
+zGTLH4kM6qHlIhABYhqME5bCVzHYmvXW+uIgVLznfIzQFyewRdMJZzCp0XxqjOkX
+yixLAoGBANbKpZVf2giL26RpUsZ8waIFc7tQAzWSqwF384XPFn8tdN1DBT3R2rQk
+8gnjX07Z6YrxkEvAhb7hDgB09EGPx1nDEXnFk1Y2xXePBccdSVQvjc/ExX0YGtBi
+ZCbiJW5+ORx8olxkNiEVUvik62470fOkWtrwO6qq77lc5QQVKlopAoGBAMvh280v
+K7o7auQxaVnjLQIoWlnKrz3+T58R/8nYFtAuiUjlT4dsBOUFKm1GE/bw8FDFc1Vo
+Z0l++KFTKNnxT6NQPRoE4JH8MZ3ycS4x0cMUK4TEW2pO11KyqlmLLdMbq1v3zgLw
+GwZ/fOOi0GlItoBY0zZYlEuXxQQUNotZLRmVAoGBAMRhgXKgx1hFWxn55UfChSZr
+Yn9fGOCGGLDissN7gkhkExNwedIe89fnQ7FE6Wyp+hiiWAq+pircZJK0EoUVvZPl
+jFITuehsl0i9RxxyjC+2cwcaTik6nCw8s1bAIjki8mMwH2pqQB4/Yc1jlWwZb3+s
+Nc98jlLlbXZGTbqXAiaLAoGBAIvOExBa3CfuOqsakWI1YLEFukwzNlZlPelrbZG4
+vy+q4cuV7WQs0CgDis6WdBcLnXk28AANE6AcjTtsOUT9PexURyfI1IFcectkat3Z
+BN2KLHhMIW135BtzMvuSoxRqvqV2uSaWA+cy2Uui2A2uNAA86JpLXl+4hxi9Zzr7
+UiArAoGBALrLwrhYtwOhMoJPK+XlMTJpLFSOUiGcFg06cvDtsUCz1H0Ma1TuHNSJ
+/El54J1bGpJ/h212wB+gAHE7nRNJfFn5vPJtqwMv/SW675SA4mlKi2xoBO1NW/sw
+FIusZ178P2e/lc+1QJoKkrM7ZKxnDvNj2Lt3B3JmXunXWZpn4i8Q
+-----END RSA PRIVATE KEY-----"""

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -42,7 +42,7 @@ class TokenCheckerTest(TestCase):
 
         # This payload will be valid as we will sign it with PRIVATE_KEY
         payload = {
-            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'iss': 'https://iam-test.idc.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
@@ -53,7 +53,7 @@ class TokenCheckerTest(TestCase):
 
         for payload in payload_list:
             token = self._create_token(payload, PRIVATE_KEY)
-            with self.settings(IAM_HOSTNAME_LIST='iam-test.indigo-datacloud.eu'):
+            with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
                 self.assertTrue(
                     self._token_checker.is_token_valid(token),
                     "Token with payload %s should not be accepted!" % payload)
@@ -74,7 +74,7 @@ class TokenCheckerTest(TestCase):
 
         # This payload will be valid as we will sign it with PRIVATE_KEY
         payload1 = {
-            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'iss': 'https://iam-test.idc.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
@@ -84,7 +84,7 @@ class TokenCheckerTest(TestCase):
         # new token is not. We need to ensure this invalid token does not
         # get granted rights based only on it's sub being in the cache
         payload2 = {
-            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'iss': 'https://iam-test.idc.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
@@ -93,14 +93,14 @@ class TokenCheckerTest(TestCase):
         token1 = self._create_token(payload1, PRIVATE_KEY)
         token2 = self._create_token(payload2, PRIVATE_KEY)
 
-        with self.settings(IAM_HOSTNAME_LIST='iam-test.indigo-datacloud.eu'):
+        with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
             self.assertTrue(
                 self._token_checker.is_token_valid(token1),
                 "Token with payload %s should not be accepted!" % payload1)
 
             self.assertFalse(
                  self._token_checker.is_token_valid(token2),
-                "Token with payload %s should not be accepted!" % payload2)
+                 "Token with payload %s should not be accepted!" % payload2)
 
     @patch.object(TokenChecker, '_get_issuer_public_key')
     def test_valid_token(self, mock_get_issuer_public_key):
@@ -113,7 +113,7 @@ class TokenCheckerTest(TestCase):
 
         # This payload will be valid as we will sign it with PRIVATE_KEY
         payload = {
-            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'iss': 'https://iam-test.idc.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
@@ -121,7 +121,7 @@ class TokenCheckerTest(TestCase):
 
         token = self._create_token(payload, PRIVATE_KEY)
 
-        with self.settings(IAM_HOSTNAME_LIST='iam-test.indigo-datacloud.eu'):
+        with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
             self.assertTrue(
                 self._token_checker.is_token_valid(token),
                 "Token with payload %s should be accepted!" % payload)
@@ -147,7 +147,7 @@ class TokenCheckerTest(TestCase):
         # This payload would be valid if properly signed, but we are going to
         # sign it with FORGED_PRIVATE_KEY which will not match the PUBLIC_KEY
         payload_list.append({
-            'iss': 'https://iam-test.indigo-datacloud.eu/',
+            'iss': 'https://iam-test.idc.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
@@ -155,7 +155,7 @@ class TokenCheckerTest(TestCase):
 
         for payload in payload_list:
             token = self._create_token(payload, FORGED_PRIVATE_KEY)
-            with self.settings(IAM_HOSTNAME_LIST='iam-test.indigo-datacloud.eu'):
+            with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
                 self.assertFalse(
                     self._token_checker._verify_token(token, payload['iss']),
                     "Payload %s should not be accepted!" % payload)
@@ -191,7 +191,7 @@ class TokenCheckerTest(TestCase):
         # to test we reject these as we do not wantt
         # to attempt to verify it
         payload_list.append({
-            'iss': 'https://malicious-iam.indigo-datacloud.biz/',
+            'iss': 'https://malicious-iam.idc.biz/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': 'ac2f23e0-8103-4581-8014-e0e82c486e36',
@@ -200,7 +200,7 @@ class TokenCheckerTest(TestCase):
         for payload in payload_list:
             token = self._create_token(payload, PRIVATE_KEY)
 
-            with self.settings(IAM_HOSTNAME_LIST='iam-test.indigo-datacloud.eu'):
+            with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
                 self.assertFalse(
                     self._token_checker._is_token_issuer_trusted(payload),
                     "Payload %s should not be accepted!" % payload)

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -1,7 +1,6 @@
 """This module tests the JSON Web Token validation."""
 
 import logging
-import unittest
 import time
 
 from jose import jwt
@@ -17,7 +16,7 @@ class TokenCheckerTest(TestCase):
 
     def setUp(self):
         """Create a new TokenChecker and disable logging."""
-        self._token_checker = TokenChecker(None, None)
+        self._token_checker = TokenChecker()
         logging.disable(logging.CRITICAL)
 
     def tearDown(self):

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -51,7 +51,7 @@ class TokenCheckerTest(TestCase):
 
         for payload in payload_list:
             token = self._create_token(payload, PRIVATE_KEY)
-            with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
+            with self.settings(IAM_HOSTNAME_LIST=['iam-test.idc.eu']):
                 self.assertEqual(
                     self._token_checker.valid_token_to_id(token), CLIENT_ID,
                     "Token with payload %s should not be accepted!" % payload
@@ -91,7 +91,7 @@ class TokenCheckerTest(TestCase):
         token1 = self._create_token(payload1, PRIVATE_KEY)
         token2 = self._create_token(payload2, PRIVATE_KEY)
 
-        with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
+        with self.settings(IAM_HOSTNAME_LIST=['iam-test.idc.eu']):
             self.assertEqual(
                 self._token_checker.valid_token_to_id(token1), CLIENT_ID,
                 "Token with payload %s should not be accepted!" % payload1
@@ -119,7 +119,7 @@ class TokenCheckerTest(TestCase):
 
         token = self._create_token(payload, PRIVATE_KEY)
 
-        with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
+        with self.settings(IAM_HOSTNAME_LIST=['iam-test.idc.eu']):
             client_id = payload['sub']
             self.assertEqual(
                 self._token_checker.valid_token_to_id(token), client_id,
@@ -150,7 +150,7 @@ class TokenCheckerTest(TestCase):
 
         for payload in payload_list:
             token = self._create_token(payload, FORGED_PRIVATE_KEY)
-            with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
+            with self.settings(IAM_HOSTNAME_LIST=['iam-test.idc.eu']):
                 self.assertFalse(
                     self._token_checker._verify_token(token, payload['iss']),
                     "Payload %s should not be accepted!" % payload
@@ -197,7 +197,7 @@ class TokenCheckerTest(TestCase):
         for payload in payload_list:
             token = self._create_token(payload, PRIVATE_KEY)
 
-            with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
+            with self.settings(IAM_HOSTNAME_LIST=['iam-test.idc.eu']):
                 self.assertFalse(
                     self._token_checker._is_token_issuer_trusted(payload),
                     "Payload %s should not be accepted!" % payload

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -10,7 +10,6 @@ from mock import patch
 from api.utils.TokenChecker import TokenChecker
 
 
-# Using unittest and not django.test as no need for overhead of database
 class TokenCheckerTest(TestCase):
     """Tests the JSON Web Token validation."""
 

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -54,7 +54,8 @@ class TokenCheckerTest(TestCase):
             with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
                 self.assertEqual(
                     self._token_checker.valid_token_to_id(token), CLIENT_ID,
-                    "Token with payload %s should not be accepted!" % payload)
+                    "Token with payload %s should not be accepted!" % payload
+                )
 
     @patch.object(TokenChecker, '_get_issuer_public_key')
     @patch.object(TokenChecker, '_check_token_not_revoked')
@@ -84,7 +85,8 @@ class TokenCheckerTest(TestCase):
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': CLIENT_ID,
-            'exp': int(time.time()) - 200}
+            'exp': int(time.time()) - 200
+        }
 
         token1 = self._create_token(payload1, PRIVATE_KEY)
         token2 = self._create_token(payload2, PRIVATE_KEY)
@@ -92,11 +94,13 @@ class TokenCheckerTest(TestCase):
         with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
             self.assertEqual(
                 self._token_checker.valid_token_to_id(token1), CLIENT_ID,
-                "Token with payload %s should not be accepted!" % payload1)
+                "Token with payload %s should not be accepted!" % payload1
+            )
 
             self.assertEqual(
                 self._token_checker.valid_token_to_id(token2), None,
-                "Token with payload %s should not be accepted!" % payload2)
+                "Token with payload %s should not be accepted!" % payload2
+            )
 
     @patch.object(TokenChecker, '_get_issuer_public_key')
     @patch.object(TokenChecker, '_check_token_not_revoked')
@@ -119,7 +123,8 @@ class TokenCheckerTest(TestCase):
             client_id = payload['sub']
             self.assertEqual(
                 self._token_checker.valid_token_to_id(token), client_id,
-                "Token with payload %s should be accepted!" % payload)
+                "Token with payload %s should be accepted!" % payload
+            )
 
     @patch.object(TokenChecker, '_get_issuer_public_key')
     def test_verify_token(self, mock_get_issuer_public_key):
@@ -148,11 +153,13 @@ class TokenCheckerTest(TestCase):
             with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
                 self.assertFalse(
                     self._token_checker._verify_token(token, payload['iss']),
-                    "Payload %s should not be accepted!" % payload)
+                    "Payload %s should not be accepted!" % payload
+                )
 
                 self.assertEqual(
                     self._token_checker.valid_token_to_id(token), None,
-                    "Token with payload %s should not be accepted!" % payload)
+                    "Token with payload %s should not be accepted!" % payload
+                )
 
     def test_is_token_issuer_trusted(self):
         """
@@ -174,7 +181,8 @@ class TokenCheckerTest(TestCase):
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': CLIENT_ID,
-            'exp': int(time.time()) + 200000})
+            'exp': int(time.time()) + 200000
+        })
 
         # Test we reject a payload with a malicious 'iss' field
         # as we do not want to attempt to verify it
@@ -183,7 +191,8 @@ class TokenCheckerTest(TestCase):
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': CLIENT_ID,
-            'exp': int(time.time()) + 200000})
+            'exp': int(time.time()) + 200000
+        })
 
         for payload in payload_list:
             token = self._create_token(payload, PRIVATE_KEY)
@@ -191,11 +200,13 @@ class TokenCheckerTest(TestCase):
             with self.settings(IAM_HOSTNAME_LIST='iam-test.idc.eu'):
                 self.assertFalse(
                     self._token_checker._is_token_issuer_trusted(payload),
-                    "Payload %s should not be accepted!" % payload)
+                    "Payload %s should not be accepted!" % payload
+                )
 
                 self.assertEqual(
                     self._token_checker.valid_token_to_id(token), None,
-                    "Token with payload %s should not be accepted!" % payload)
+                    "Token with payload %s should not be accepted!" % payload
+                )
 
     def test_is_token_json_temporally_valid(self):
         """
@@ -215,7 +226,8 @@ class TokenCheckerTest(TestCase):
         payload_list.append({
             'sub': CLIENT_ID,
             'iss': 'https://iam-test.indigo-datacloud.eu/',
-            'jti': '714892f5-014f-43ad-bea0-fa47579db222'})
+            'jti': '714892f5-014f-43ad-bea0-fa47579db222'
+        })
 
         # Test that we reject a payload without 'exp'
         # as such a token would never expire
@@ -223,7 +235,8 @@ class TokenCheckerTest(TestCase):
             'iss': 'https://iam-test.indigo-datacloud.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
-            'sub': CLIENT_ID})
+            'sub': CLIENT_ID
+        })
 
         # Test that we reject a payload without 'iat'
         # as all tokens should indicate when they were issued
@@ -231,7 +244,8 @@ class TokenCheckerTest(TestCase):
             'iss': 'https://iam-test.indigo-datacloud.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'sub': CLIENT_ID,
-            'exp': int(time.time()) + 200000})
+            'exp': int(time.time()) + 200000
+        })
 
         # Test that we reject a payload with an 'iat' and 'exp'
         # in the past (e.g. they have expired)
@@ -240,7 +254,8 @@ class TokenCheckerTest(TestCase):
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': CLIENT_ID,
-            'exp': int(time.time()) - 200000})
+            'exp': int(time.time()) - 200000
+        })
 
         # Test that we reject a payload with an 'iat' and 'exp'
         # in the future (as we should as they are not yet valid)
@@ -249,7 +264,8 @@ class TokenCheckerTest(TestCase):
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) + 200000,
             'sub': CLIENT_ID,
-            'exp': int(time.time()) + 2000000})
+            'exp': int(time.time()) + 2000000
+        })
 
         for payload in payload_list:
             # Assert the underlying helper method reponsible for
@@ -257,14 +273,16 @@ class TokenCheckerTest(TestCase):
             # temporally invalid payloads
             self.assertFalse(
                 self._token_checker._is_token_json_temporally_valid(payload),
-                "Payload %s should not be accepted!" % payload)
+                "Payload %s should not be accepted!" % payload
+            )
 
             # Assert the wrapper method valid_token_to_id returns
             # None when passed temporally invalid tokens
             token = self._create_token(payload, PRIVATE_KEY)
             self.assertEqual(
                 self._token_checker.valid_token_to_id(token), None,
-                "Token with payload %s should not be accepted!" % payload)
+                "Token with payload %s should not be accepted!" % payload
+            )
 
     def test_garbage_token(self):
         """Test a garbage token is rejected."""
@@ -277,11 +295,13 @@ class TokenCheckerTest(TestCase):
         self.assertEqual(
             self._token_checker._check_token_not_revoked(None,
                                                          'http://idc.org'),
-            None)
+            None
+        )
 
         self.assertFalse(
             self._token_checker._verify_token(None,
-                                              'http://idc.org'))
+                                              'http://idc.org')
+        )
 
     def _create_token(self, payload, key):
         """Return a token, signed by key, correspond to the payload."""
@@ -294,7 +314,8 @@ class TokenCheckerTest(TestCase):
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': CLIENT_ID,
-            'exp': int(time.time()) + 200000}
+            'exp': int(time.time()) + 200000
+        }
 
 
 # Use this Client ID in tokens

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -293,7 +293,8 @@ class TokenCheckerTest(TestCase):
         return jwt.encode(payload, key, algorithm='RS256')
 
     def _standard_token(self):
-        return  {
+        """Return a token that will ve valid if properly signed."""
+        return {
             'iss': 'https://iam-test.idc.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -291,6 +291,23 @@ class TokenCheckerTest(TestCase):
                 self._token_checker.valid_token_to_id(token), None,
                 "Token with payload %s should not be accepted!" % payload)
 
+    def test_garbage_token(self):
+        """Test a garbage token is rejected."""
+        token = 'ffnnsdifsdjofjfosdjfodsjfosdjofj'
+        result = self._token_checker.valid_token_to_id(token)
+        self.assertEqual(result, None)
+
+    def test_http_issuer_ban(self):
+        """Test a a HTTP issuer is rejected."""
+        self.assertEqual(
+            self._token_checker._check_token_not_revoked(None,
+                                                         'http://idc.org'),
+            None)
+
+        self.assertFalse(
+            self._token_checker._verify_token(None,
+                                              'http://idc.org'))
+
     def _create_token(self, payload, key):
         """Return a token, signed by key, correspond to the payload."""
         return jwt.encode(payload, key, algorithm='RS256')

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -30,7 +30,7 @@ class TokenCheckerTest(TestCase):
         Check a cached token is granted access.
 
         Method does this by checking a token is valid twice, the first time
-        the token is validate and stored in a cache, the second time access
+        the token is validated and stored in a cache, the second time access
         should be granted because the token is in the cache, not because the
         token is valid.
         """
@@ -63,7 +63,7 @@ class TokenCheckerTest(TestCase):
         """
         Check tokens with the same subject are handled correctly.
 
-        Having a token cached for the sub should not be sufficent to grant
+        Having a token cached for the subject should not be sufficent to grant
         access, the tokens must match.
         """
         # Mock the external call to retrieve the IAM public key
@@ -78,7 +78,7 @@ class TokenCheckerTest(TestCase):
 
         # This payload has a subject that will be in the cache, but this
         # new token is not. We need to ensure this invalid token does not
-        # get granted rights based only on it's sub being in the cache
+        # get granted rights based only on it's subject being in the cache
         payload2 = {
             'iss': 'https://iam-test.idc.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
@@ -168,18 +168,16 @@ class TokenCheckerTest(TestCase):
         """
         payload_list = []
 
-        # Add a payload without 'iss' field.
-        # to test we reject these as we cannot
-        # tell where it came from (so can't verify it)
+        # Test we reject a payload without 'iss' field
+        # as we cannot tell where it came from (so can't verify it)
         payload_list.append({
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': CLIENT_ID,
             'exp': int(time.time()) + 200000})
 
-        # Add a payload with a malicious 'iss' field.
-        # to test we reject these as we do not wantt
-        # to attempt to verify it
+        # Test we reject a payload with a malicious 'iss' field
+        # as we do not want to attempt to verify it
         payload_list.append({
             'iss': 'https://malicious-iam.idc.biz/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
@@ -212,32 +210,31 @@ class TokenCheckerTest(TestCase):
         """
         payload_list = []
 
-        # Add a payload wihtout 'iat' or 'exp' to the payload list
-        # to test we reject these (as we are choosing to)
+        # Test that we reject a payload without 'iat' or 'exp'
+        # as the tokens should have a lifetime
         payload_list.append({
             'sub': CLIENT_ID,
             'iss': 'https://iam-test.indigo-datacloud.eu/',
             'jti': '714892f5-014f-43ad-bea0-fa47579db222'})
 
-        # Add a payload without 'exp' to the payload_list
-        # to test we reject these (as we are choosing to)
+        # Test that we reject a payload without 'exp'
+        # as such a token would never expire
         payload_list.append({
             'iss': 'https://iam-test.indigo-datacloud.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'iat': int(time.time()) - 2000000,
             'sub': CLIENT_ID})
 
-        # Add a payload without 'iat'
-        # to test we reject these (as we are choosing to)
+        # Test that we reject a payload without 'iat'
+        # as all tokens should indicate when they were issued
         payload_list.append({
             'iss': 'https://iam-test.indigo-datacloud.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
             'sub': CLIENT_ID,
             'exp': int(time.time()) + 200000})
 
-        # Add a payload with an 'iat' and 'exp' in the past
-        # (e.g. they have expired) to test we are
-        # rejecting these
+        # Test that we reject a payload with an 'iat' and 'exp'
+        # in the past (e.g. they have expired)
         payload_list.append({
             'iss': 'https://iam-test.indigo-datacloud.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
@@ -245,9 +242,8 @@ class TokenCheckerTest(TestCase):
             'sub': CLIENT_ID,
             'exp': int(time.time()) - 200000})
 
-        # Add a payload with an 'iat' and 'exp' in the future
-        # to test we are rejecting these (as we should as they
-        # are not yet valid)
+        # Test that we reject a payload with an 'iat' and 'exp'
+        # in the future (as we should as they are not yet valid)
         payload_list.append({
             'iss': 'https://iam-test.indigo-datacloud.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
@@ -263,7 +259,7 @@ class TokenCheckerTest(TestCase):
                 self._token_checker._is_token_json_temporally_valid(payload),
                 "Payload %s should not be accepted!" % payload)
 
-            # Assert the wrapper method valid_token_to_id reutrns
+            # Assert the wrapper method valid_token_to_id returns
             # None when passed temporally invalid tokens
             token = self._create_token(payload, PRIVATE_KEY)
             self.assertEqual(
@@ -277,7 +273,7 @@ class TokenCheckerTest(TestCase):
         self.assertEqual(result, None)
 
     def test_http_issuer_ban(self):
-        """Test a a HTTP issuer is rejected."""
+        """Test a HTTP issuer is rejected."""
         self.assertEqual(
             self._token_checker._check_token_not_revoked(None,
                                                          'http://idc.org'),
@@ -292,7 +288,7 @@ class TokenCheckerTest(TestCase):
         return jwt.encode(payload, key, algorithm='RS256')
 
     def _standard_token(self):
-        """Return a token that will ve valid if properly signed."""
+        """Return a token that will be valid if properly signed."""
         return {
             'iss': 'https://iam-test.idc.eu/',
             'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',

--- a/api/tests/test_token_checker.py
+++ b/api/tests/test_token_checker.py
@@ -45,12 +45,7 @@ class TokenCheckerTest(TestCase):
         payload_list = []
 
         # This payload will be valid as we will sign it with PRIVATE_KEY
-        payload = {
-            'iss': 'https://iam-test.idc.eu/',
-            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
-            'iat': int(time.time()) - 2000000,
-            'sub': CLIENT_ID,
-            'exp': int(time.time()) + 200000}
+        payload = self._standard_token()
 
         # Add the same token twice, this is what tests the cache functionality
         payload_list = [payload, payload]
@@ -80,12 +75,7 @@ class TokenCheckerTest(TestCase):
         mock_check_token_not_revoked.return_value = CLIENT_ID
 
         # This payload will be valid as we will sign it with PRIVATE_KEY
-        payload1 = {
-            'iss': 'https://iam-test.idc.eu/',
-            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
-            'iat': int(time.time()) - 2000000,
-            'sub': CLIENT_ID,
-            'exp': int(time.time()) + 200000}
+        payload1 = self._standard_token()
 
         # This payload has a subject that will be in the cache, but this
         # new token is not. We need to ensure this invalid token does not
@@ -122,12 +112,7 @@ class TokenCheckerTest(TestCase):
         mock_check_token_not_revoked.return_value = CLIENT_ID
 
         # This payload will be valid as we will sign it with PRIVATE_KEY
-        payload = {
-            'iss': 'https://iam-test.idc.eu/',
-            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
-            'iat': int(time.time()) - 2000000,
-            'sub': CLIENT_ID,
-            'exp': int(time.time()) + 200000}
+        payload = self._standard_token()
 
         token = self._create_token(payload, PRIVATE_KEY)
 
@@ -157,12 +142,7 @@ class TokenCheckerTest(TestCase):
 
         # This payload would be valid if properly signed, but we are going to
         # sign it with FORGED_PRIVATE_KEY which will not match the PUBLIC_KEY
-        payload_list.append({
-            'iss': 'https://iam-test.idc.eu/',
-            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
-            'iat': int(time.time()) - 2000000,
-            'sub': CLIENT_ID,
-            'exp': int(time.time()) + 200000})
+        payload_list.append(self._standard_token())
 
         for payload in payload_list:
             token = self._create_token(payload, FORGED_PRIVATE_KEY)
@@ -311,6 +291,15 @@ class TokenCheckerTest(TestCase):
     def _create_token(self, payload, key):
         """Return a token, signed by key, correspond to the payload."""
         return jwt.encode(payload, key, algorithm='RS256')
+
+    def _standard_token(self):
+        return  {
+            'iss': 'https://iam-test.idc.eu/',
+            'jti': '098cb343-c45e-490d-8aa0-ce1873cdc5f8',
+            'iat': int(time.time()) - 2000000,
+            'sub': CLIENT_ID,
+            'exp': int(time.time()) + 200000}
+
 
 # Use this Client ID in tokens
 CLIENT_ID = 'ac2f23e0-8103-4581-8014-e0e82c486e36'

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -20,7 +20,7 @@ class TokenChecker(object):
         self.logger = logging.getLogger(__name__)
 
     def valid_token_to_id(self, token):
-        """Introspect a token to determine it's origin."""
+        """Introspect a token to determine its origin."""
         try:
             jwt_unverified_json = jwt.get_unverified_claims(token)
         except JWTError:
@@ -46,7 +46,7 @@ class TokenChecker(object):
 
         issuer = jwt_unverified_json['iss']
         # we can pass issuer because the previous 'if' statement
-        #  returns if jwt_unverified_json['iss'] is missing.
+        # returns if jwt_unverified_json['iss'] is missing.
         issuer = jwt_unverified_json['iss']
         if not self._verify_token(token, issuer):
             return None
@@ -58,10 +58,10 @@ class TokenChecker(object):
             return None
 
         self.logger.info('Token validated')
-        # if the execution gets here, we can cache the token
-        # cache is a key: value like structure with an optional timeout
-        # as we only need the token stored we use that as the key
-        # and None as the value.
+        # If the execution gets here, we can cache the token.
+        # The cache variable is a key: value like structure
+        # with an optional timeout, we use the token subject
+        # as the key and the token as the value.
         # Cache timeout set to 300 seconds to enable quick revocation
         # but also limit the number of requests to the IAM instance
         # Caching is also done after token validation to ensure

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -38,7 +38,7 @@ class TokenChecker:
         return True
 
     def _verify_token(self, token, issuer):
-        """."""
+        """Fetch IAM public key and veifry token against it."""
         if "https://" not in issuer:
             self.logger.info('Issuer not https! Will not verify token!')
             return False

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -15,13 +15,9 @@ from jose.exceptions import ExpiredSignatureError, JWTClaimsError, JWTError
 class TokenChecker:
     """This class contains methods to check a JWT token for validity."""
 
-    def __init__(self, cert, key):
+    def __init__(self):
         """Initialize a new TokenChecker."""
         self.logger = logging.getLogger(__name__)
-        # cache is used to maintain an dicitonary of issuer/cache cut off pairs
-        self.cache = {}
-        self._cert = cert
-        self._key = key
 
     def valid_token_to_id(self, token):
         """Introspect a token to determine it's origin."""

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -1,0 +1,51 @@
+"""This module contains the TokenChecker class."""
+import datetime
+import logging
+
+from jose import jwt
+
+
+class TokenChecker:
+    """This class contains methods to check a JWT token for validity."""
+
+    def __init__(self):
+        """Initialize a new TokenChecker."""
+        self.logger = logging.getLogger(__name__)
+        # cache is used to maintain an dicitonary of issuer/cache cut off pairs
+        self.cache = {}
+
+    def is_token_valid(self, token):
+        """Introspect a token to determine it's origin."""
+        jwt_unverified_json = jwt.get_unverified_claims(token)
+
+        if not self._is_token_json_temporally_valid(jwt_unverified_json):
+            return False
+
+        return True
+
+    def _is_token_json_temporally_valid(self, token_json):
+        """
+        Check JWT Token JSON is temporarily valid.
+
+        Return True if:
+         - Both 'Issued At' (iat) and Expired' (exp) are present
+         - iat is in the past
+         - exp is in the future
+        """
+        now = int(datetime.datetime.now().strftime('%s'))
+        try:
+            # check 'iat' (issued at) is in the past and 'exp' (expires at)
+            # is in the future
+            if token_json['iat'] > now or token_json['exp'] < now:
+                self.logger.info("Token 'iat' or 'exp' invalid")
+                self.logger.debug(token_json)
+                self.logger.debug("Time now: %s", now)
+                return False
+        # it's possible a token doesn't have an 'iat' or 'exp'
+        except KeyError:
+            self.logger.info("Token missing 'iat' or 'exp'")
+            self.logger.debug(token_json)
+            return False
+
+        # if we get here, the token is temporarily valid
+        return True

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -108,11 +108,8 @@ class TokenChecker:
             self.logger.info('Issuer not https! Will not verify token!')
             return False
 
-        # extract the IAM hostname from the issuer
-        hostname = issuer.replace("https://", "").replace("/", "")
-
         # get the IAM's public key
-        key_json = self._get_issuer_public_key(hostname)
+        key_json = self._get_issuer_public_key(issuer)
 
         # if we couldn't get the IAM public key, we cannot verify the token.
         if key_json is None:

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -81,7 +81,7 @@ class TokenChecker:
 
     def _is_token_issuer_trusted(self, token_json):
         """
-        Return True if the payload 'issuer' is in settings.IAM_HOSTNAME_LIST.
+        Return True if the 'issuer' hostname is in settings.IAM_HOSTNAME_LIST.
 
         Otherwise (or if 'iss' missng) return False.
         """
@@ -92,7 +92,10 @@ class TokenChecker:
             self.logger.debug(token_json)
             return False
 
-        if issuer in settings.IAM_HOSTNAME_LIST:
+        # extract the IAM hostname from the issuer
+        hostname = issuer.replace("https://", "").replace("/", "")
+
+        if hostname in settings.IAM_HOSTNAME_LIST:
             self.logger.info("Token 'iss' from approved IAM")
             self.logger.debug(token_json)
             return True

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -26,7 +26,12 @@ class TokenChecker:
 
     def valid_token_to_id(self, token):
         """Introspect a token to determine it's origin."""
-        jwt_unverified_json = jwt.get_unverified_claims(token)
+        try:
+            jwt_unverified_json = jwt.get_unverified_claims(token)
+        except JWTError:
+            self.logger.error('Token cannot be decoded.')
+            self.logger.debug('Full token: %s' %token)
+            return None
 
         unverified_token_id = jwt_unverified_json['sub']
         self.logger.info('Token claims to be from %s' % unverified_token_id)

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -29,10 +29,11 @@ class TokenChecker:
         jwt_unverified_json = jwt.get_unverified_claims(token)
 
         unverified_token_id = jwt_unverified_json['sub']
+        self.logger.info('Token claims to be from %s' % unverified_token_id)
+
         # if token is in the cache, we say it is valid
         if cache.get(unverified_token_id) == token:
-            self.logger.info("Token for user %s is in cache." %
-                             unverified_token_id)
+            self.logger.info("Token is in cache.")
 
             return jwt_unverified_json['sub']
 
@@ -56,6 +57,7 @@ class TokenChecker:
         if verifed_token_id != jwt_unverified_json['sub']:
             return None
 
+        self.logger.info('Token validated')
         # if the execution gets here, we can cache the token
         # cache is a key: value like structure with an optional timeout
         # as we only need the token stored we use that as the key
@@ -98,7 +100,6 @@ class TokenChecker:
             self.logger.error("%s: %s", type(error), str(error))
             return None
 
-        self.logger.info("Token identifed as belonging to %s", client_id)
         return client_id
 
     def _verify_token(self, token, issuer):
@@ -160,7 +161,7 @@ class TokenChecker:
         hostname = issuer.replace("https://", "").replace("/", "")
 
         if hostname in settings.IAM_HOSTNAME_LIST:
-            self.logger.info("Token 'iss' is an approved IAM")
+            self.logger.info("Token 'iss' %s is an approved IAM" % hostname)
             self.logger.debug(token_json)
             return True
         else:

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -25,11 +25,11 @@ class TokenChecker:
             jwt_unverified_json = jwt.get_unverified_claims(token)
         except JWTError:
             self.logger.error('Token cannot be decoded.')
-            self.logger.debug('Full token: %s' %token)
+            self.logger.debug('Full token: %s', token)
             return None
 
         unverified_token_id = jwt_unverified_json['sub']
-        self.logger.info('Token claims to be from %s' % unverified_token_id)
+        self.logger.info('Token claims to be from %s', unverified_token_id)
 
         # if token is in the cache, we say it is valid
         if cache.get(unverified_token_id) == token:
@@ -161,7 +161,7 @@ class TokenChecker:
         hostname = issuer.replace("https://", "").replace("/", "")
 
         if hostname in settings.IAM_HOSTNAME_LIST:
-            self.logger.info("Token 'iss' %s is an approved IAM" % hostname)
+            self.logger.info("Token 'iss' %s is an approved IAM", hostname)
             self.logger.debug(token_json)
             return True
         else:

--- a/api/utils/TokenChecker.py
+++ b/api/utils/TokenChecker.py
@@ -12,7 +12,7 @@ from jose import jwt
 from jose.exceptions import ExpiredSignatureError, JWTClaimsError, JWTError
 
 
-class TokenChecker:
+class TokenChecker(object):
     """This class contains methods to check a JWT token for validity."""
 
     def __init__(self):

--- a/api/utils/__init__.py
+++ b/api/utils/__init__.py
@@ -1,0 +1,18 @@
+"""
+Copyright (C) 2016 STFC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+@author Greg Corbett
+"""
+__version__ = '1, 3, 0'

--- a/api/utils/__init__.py
+++ b/api/utils/__init__.py
@@ -1,18 +1,1 @@
-"""
-Copyright (C) 2016 STFC.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-@author Greg Corbett
-"""
-__version__ = '1, 3, 0'
+"""This file allows utils to be imported as a python package."""

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -1,13 +1,9 @@
 """This file contains the CloudRecordSummaryView class."""
 
-import base64
 import ConfigParser
 import datetime
-import httplib
-import json
 import logging
 import MySQLdb
-import urllib2
 
 from rest_framework.pagination import PaginationSerializer
 from django.conf import settings
@@ -48,8 +44,7 @@ class CloudRecordSummaryView(APIView):
     def __init__(self):
         """Set up class level logging."""
         self.logger = logging.getLogger(__name__)
-        self._token_checker = TokenChecker('/etc/httpd/ssl/apache.crt',
-                                           '/etc/httpd/ssl/apache.key')
+        self._token_checker = TokenChecker()
         super(CloudRecordSummaryView, self).__init__()
 
     def get(self, request, format=None):

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -8,7 +8,7 @@ sed -i "s|not_a_secure_secret|$DJANGO_SECRET_KEY|g" /var/www/html/apel_rest/sett
 sed -i "s|provider_url|$PROVIDERS_URL|g" /var/www/html/apel_rest/settings.py
 
 # IAM_URL
-sed -i "s|iam_url|$IAM_URL|g" /var/www/html/apel_rest/settings.py
+sed -i "s|\['allowed_iams'\]|$IAM_URLS|g" /var/www/html/apel_rest/settings.py
 
 # SERVER_IAM_ID
 sed -i "s|server_iam_id|$SERVER_IAM_ID|g" /var/www/html/apel_rest/settings.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dirq
 django==1.6.3
 djangorestframework==3.0.5
+python-jose
 MySQL-python

--- a/yaml/apel_rest_interface.env
+++ b/yaml/apel_rest_interface.env
@@ -4,7 +4,7 @@ DJANGO_SECRET_KEY=Put_a_secret_here
 PROVIDERS_URL=http://indigo.cloud.plgrid.pl/cmdb/service/list
 
 # The introspect URL for the IAM repsonsible for token based authN/authZ
-IAM_URL=https://iam-test.indigo-datacloud.eu/introspect
+IAM_URLS=[\'iam-test.indigo-datacloud.eu\']
 # The ID and secret of this service as registered with the sbove IAM
 SERVER_IAM_ID=
 SERVER_IAM_SECRET=


### PR DESCRIPTION
As per Indigo IAM best practices:

- Tokens will now be introspected for temporal validaty (issued in the past, expires in the future) and that they are from one of possibly many 'trusted' IAM as defined by the `IAM_HOSTNAME_LIST` in `apel_rest/settings.py` file.

- Tokens are verified by getting the public key of its trusted issuer.

- Tokens are now cached for 5 minutes on a successful request to reduce load on the IAM.

`docker.run_on_entry.py` and `yaml/apel_rest_interface` have also been changed to allow deployment with support for multiple IAMs

Tests have also been added for the `TokenChecker` class and existing `CloudRecordSummaryView` tests have had this new functionality mocked away as they use garbage tokens.