### PR TITLE
Remove coveralls from the Docker Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ sudo: false
 # Cache the dependencies installed by pip
 cache: pip
 
-# Install defaults to "pip install -r requirements.txt"
+install:
+  - pip install -r requirements.txt
+  - pip install -r test_requirements.txt
 
 # Commands that prepare things for the test
 before_script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
+dirq
 django==1.6.3
 djangorestframework==3.0.5
-dirq
-# Dependencies for CI testing
 MySQL-python
-coveralls

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,2 @@
+# Dependencies for CI testing
+coveralls


### PR DESCRIPTION
[coveralls 1.2.0](https://pypi.python.org/pypi/coveralls/1.2.0) has been released. This has seemingly introduced a new dependency on a non python package `libffi`. This package was not being installed into the Docker image during the Docker Hub [builds](https://hub.docker.com/r/gregcorbett/rest/builds/bkdzdrcc4rnbn9zpxrcrgcg/), as such the builds were failing.

To fix the Docker builds, this PR splits `requirements.txt` into:

- `requirements.txt` - requirements used at run time
- `test_requirements.txt` - requirements used for testing only

This means the Docker build does not try and install `coveralls` (or any future testing only dependencies) into the Docker image.

In order to continue to allow the test to pass on travis, `.travis.yml` has been changed to install both `requirements.txt` and `test_requirements.txt`, as both sets of requirements are needed for the tests to run.

Other options considered were:
- fix `coveralls` to version 1.1.0, this felt like a bad idea as it locks us into the older version unnecessarily.
- install `libffi` into the Docker image, but given that coveralls is a testing requirement and not used a run time, I thought it didn't seem sensible to add an additional testing dependency into the build that wasn't being used at run time.