### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.6"
+  - "nightly"
 matrix:
   allow_failures:
-    - python: "3.6"
+    - python: "nightly"
   fast_finish: true
 
 # use the mysql service
@@ -16,6 +16,8 @@ services:
 sudo: false
 # Cache the dependencies installed by pip
 cache: pip
+# Avoid pip log from affecting cache
+before_cache: rm -fv ~/.cache/pip/log/debug.log
 
 install:
   - pip install -r requirements.txt
@@ -29,6 +31,6 @@ before_script:
   - export PYTHONPATH=$PYTHONPATH:`pwd -P`
 
 # Command to run tests
-script: coverage run --source='.' manage.py test
+script: coverage run --branch --source='.' manage.py test
 
 after_success: coveralls


### PR DESCRIPTION
- Remove pip log before caching to avoid it affecting the cache.
- Add --branch argument to coverage run as the coveralls module
  reports coverage to Coveralls.io now.
- Test against latest nightly rather than a fixed Python 3 version so
  that it doesn't have to be manually changed in future.