### PR TITLE
Upgrade base Docker image to Centos7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM centos:6
+FROM centos:7
 
 MAINTAINER APEL Administrator <apel-admins@stfc.ac.uk>
 
 # Add EPEL repo so we can get pip
-RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
 
 # Add IGTF trust repo, so it can be installed
 RUN touch /etc/yum.repos.d/EGI-trustanchors.repo

--- a/conf/apel_rest_api.conf
+++ b/conf/apel_rest_api.conf
@@ -5,7 +5,7 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
 
 <Directory /var/www/html/apel_rest>
 <Files wsgi.py>
-Allow from all
+Require all granted
 </Files>
 </Directory>
 
@@ -17,5 +17,5 @@ WSGIPassAuthorization On
 
 Alias /static "/usr/lib/python2.6/site-packages/rest_framework/static"
 <Directory "/usr/lib/python2.6/site-packages/rest_framework/static">
-Allow from all
+Require all granted
 </Directory>

--- a/conf/apel_rest_api.conf
+++ b/conf/apel_rest_api.conf
@@ -15,7 +15,7 @@ WSGIProcessGroup apel_rest
 WSGIScriptAlias / /var/www/html/apel_rest/wsgi.py
 WSGIPassAuthorization On
 
-Alias /static "/usr/lib/python2.6/site-packages/rest_framework/static"
-<Directory "/usr/lib/python2.6/site-packages/rest_framework/static">
+Alias /static "/usr/lib/python2.7/site-packages/rest_framework/static"
+<Directory "/usr/lib/python2.7/site-packages/rest_framework/static">
 Require all granted
 </Directory>

--- a/conf/ssl.conf
+++ b/conf/ssl.conf
@@ -9,7 +9,7 @@
 # consult the online docs. You have been warned.  
 #
 
-LoadModule ssl_module modules/mod_ssl.so
+# LoadModule ssl_module modules/mod_ssl.so
 
 #
 # When we also provide SSL we have to listen to the 
@@ -39,7 +39,7 @@ SSLSessionCacheTimeout  300
 #   Semaphore:
 #   Configure the path to the mutual exclusion semaphore the
 #   SSL engine uses internally for inter-process synchronization. 
-SSLMutex default
+Mutex default
 
 #   Pseudo Random Number Generator (PRNG):
 #   Configure one or more sources to seed the PRNG of the 
@@ -174,7 +174,7 @@ SSLVerifyDepth  10
 #   o OptRenegotiate:
 #     This enables optimized SSL connection renegotiation handling when SSL
 #     directives are used in per-directory context. 
-SSLOptions +StdEnvVars +FakeBasicAuth +ExportCertData +StrictRequire
+SSLOptions +StdEnvVars +FakeBasicAuth +ExportCertData +StrictRequire +LegacyDNStringFormat
 <Files ~ "\.(cgi|shtml|phtml|php3?)$">
     SSLOptions +StdEnvVars
 </Files>

--- a/conf/ssl.conf
+++ b/conf/ssl.conf
@@ -9,6 +9,8 @@
 # consult the online docs. You have been warned.  
 #
 
+# This is already loaded by httpd 2.4,
+# so doesn't need re-loading here.
 # LoadModule ssl_module modules/mod_ssl.so
 
 #

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -28,17 +28,21 @@ sed -i "s|\['allowed_for_get'\]|$ALLOWED_FOR_GET|g" /var/www/html/apel_rest/sett
 
 # fetch the crl first
 fetch-crl
-# then start the periodic fetch-url
-service fetch-crl-cron start
+
+# alter the fetch-crl cron to run regardless of any services
+echo "# Cron job running by default every 6 hours, at 45 minutes past the hour
+# with  +/- 3 minutes sleep.
+
+45 */6 * * * root /usr/sbin/fetch-crl -q -r 360" >  /etc/cron.d/fetch-crl
 
 # start apache
-service httpd start
+/usr/sbin/httpd
 
 # start cron
-service crond start
+/usr/sbin/crond
 
 # start at
-service atd start
+/usr/sbin/atd
 
 # install IGTF trust bundle 10 minutes after start up
 echo "yum -y update ca-policy-egi-core >> /var/log/IGTF-startup-update.log" | at now + 10 min


### PR DESCRIPTION
The Indigo SQA team have requested the Docker image be upgraded to Centos7. This PR does that.
It does so in the 'easiest' way, resulting in minimal changes, as the next release is the last release of the project.

`systemd` is not present in the Centos7 docker images, so we can't start 'services'. This solution runs `httpd`, `crond` and `atd` as processes and changes the `fetch-crl-cron` job to not be dependent on a service, which is the default behaviour of `fetch-crl-cron` so previously we didn't have to change the cron job.

`httpd` for Centos7 is a newer version than for Centos6 and requires some changes (as per [Upgrading to 2.4 from 2.2](https://httpd.apache.org/docs/current/upgrading.html)).
- change `Allow for all` to `Require all granted`
- `SSLMutex` has been replaced with the `Mutex` directive, so `ssl.conf` has changed as well
- add `LegacyDNStringFormat` to `SSLOptions` to continue to use the now non-default slash separated DN format, rather than change the software.

