### PR TITLE
Update docker/README.md to refer to main README.md

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
 # Using the Docker containers
 This directory contains files necessary for Docker based deployment.
 
-To find out how to run the 'APEL for Indigo DataCloud' containers, please refer to these [instructions](../README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604).
+To find out how to run the 'APEL for Indigo DataCloud' containers, please refer to [these instructions](../README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604).

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
 # Using the Docker containers
-Run the `run_container.sh` script.
+This directory contains files necessary for Docker based deployment.
 
-This will get the Docker image for the APEL REST API (including the server) and configure the persistant database container and launch an instance of the APEL Rest interface.
+To find out how to run the 'APEL for Indigo DataCloud' containers, please refer to these [instructions](../README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604).


### PR DESCRIPTION
The instructions in `docker/README.md` are outdated and have been superseded by `README.md`. 

This PR changes `docker/README.md` to refer to `README.md` rather than duplicate documentation