### PR TITLE
Change EPEL release RPM referenced in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 MAINTAINER APEL Administrator <apel-admins@stfc.ac.uk>
 
 # Add EPEL repo so we can get pip
-RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 # Add IGTF trust repo, so it can be installed
 RUN touch /etc/yum.repos.d/EGI-trustanchors.repo


### PR DESCRIPTION
Resolves #45   

The previous link to the EPEL release rpm is no longer valid. As such the `rpm` command fails which cause the docker build to fail.

This PR fixes the build ([latest build](https://hub.docker.com/r/gregcorbett/rest/builds/br6nzaprxm5ntrnyfpibyen/)).