### PR TITLE
Prevent lack of provider JSON blocking POST requests

### DIFF
--- a/api/tests/test_cloud_record_helper.py
+++ b/api/tests/test_cloud_record_helper.py
@@ -24,7 +24,8 @@ class CloudRecordHelperTest(TestCase):
         """
         # mock the external call to the CMDB to retrieve the providers
         # used in the _signer_is_valid method we are testing
-        CloudRecordView._get_provider_list = Mock(return_value=PROVIDERS)
+        mock_providers = Mock(return_value=PROVIDERS)
+        CloudRecordView._get_provider_json_indigo_cmdb = mock_providers
         test_cloud_view = CloudRecordView()
 
         # The DN corresponds to a host listed as a provider
@@ -65,6 +66,6 @@ class CloudRecordHelperTest(TestCase):
         # mock the external call to the CMDB to retrieve the providers
         # used in the _signer_is_valid method we are testing
         # now we are mocking a failure of the CMDB to respond as expected
-        CloudRecordView._get_provider_list = Mock(return_value={})
+        CloudRecordView._get_provider_json_indigo_cmdb = Mock(return_value={})
         # in which case we should reject all POST requests
         self.assertFalse(test_cloud_view._signer_is_valid(allowed_dn))

--- a/api/tests/test_cloud_record_post.py
+++ b/api/tests/test_cloud_record_post.py
@@ -56,7 +56,7 @@ class CloudRecordPostTest(TestCase):
         # Used in the underlying POST handling method
         # Shouldn't allow any POSTs,
         # i.e. we have failed to retrieve the providers list
-        CloudRecordView._get_provider_list = Mock(return_value={})
+        CloudRecordView._get_provider_json_indigo_cmdb = Mock(return_value={})
 
         # Make (and check) the POST request
         self._check_record_post(MESSAGE, 403)
@@ -66,7 +66,8 @@ class CloudRecordPostTest(TestCase):
         # Mock the functionality of the provider list
         # Used in the underlying POST handling method
         # Allows only allowed_host.test to POST
-        CloudRecordView._get_provider_list = Mock(return_value=PROVIDERS)
+        mock_providers = Mock(return_value=PROVIDERS)
+        CloudRecordView._get_provider_json_indigo_cmdb = mock_providers
 
         example_dn = "/C=XX/O=XX/OU=XX/L=XX/CN=prohibited_host.test"
 
@@ -84,7 +85,8 @@ class CloudRecordPostTest(TestCase):
         # Used in the underlying POST handling method so that the
         # default dn used in _check_record_post is authorized
         # to make POST request.
-        CloudRecordView._get_provider_list = Mock(return_value=PROVIDERS)
+        mock_providers = Mock(return_value=PROVIDERS)
+        CloudRecordView._get_provider_json_indigo_cmdb = mock_providers
         # Make (and check) the POST request
         self._check_record_post(MESSAGE, 202)
 

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -153,6 +153,8 @@ class CloudRecordView(APIView):
             return False
 
         if signer in self._get_indigo_providers():
+            self.logger.info("Host %s is listed as an INDIGO provider.",
+                             signer)
             return True
 
         if signer_dn in settings.ALLOWED_TO_POST:

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -125,7 +125,10 @@ class CloudRecordView(APIView):
         except KeyError:
             # The returned provider JSON is not of expected format.
             self.logger.error('Could not parse provider JSON.')
-            return False
+            # Set enumerated_providers to the empty list and
+            # allow the method to continue incase the
+            # signer_dn has special access.
+            enumerated_providers = []
 
         for _, site_json in enumerated_providers:
             try:

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -152,13 +152,13 @@ class CloudRecordView(APIView):
             self.logger.info("Host %s is banned.", signer)
             return False
 
+        if signer_dn in settings.ALLOWED_TO_POST:
+            self.logger.info("Host %s has special access.", signer)
+            return True
+
         if signer in self._get_indigo_providers():
             self.logger.info("Host %s is listed as an INDIGO provider.",
                              signer)
-            return True
-
-        if signer_dn in settings.ALLOWED_TO_POST:
-            self.logger.info("Host %s has special access.", signer)
             return True
 
         # If we have not returned already

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -95,12 +95,12 @@ class CloudRecordView(APIView):
 #                                                                             #
 ###############################################################################
 
-    def _get_provider_list(self):
-        """Return a list of Resource Providers."""
+    def _get_provider_json_indigo_cmdb(self):
+        """Fetch the INDIGO CMDB Resource Provider JSON."""
         try:
-            provider_list_request = urllib2.Request(settings.PROVIDERS_URL)
-            provider_list_response = urllib2.urlopen(provider_list_request)
-            return json.loads(provider_list_response.read())
+            provider_json_request = urllib2.Request(settings.PROVIDERS_URL)
+            provider_json_response = urllib2.urlopen(provider_json_request)
+            return json.loads(provider_json_response.read())
 
         except (ValueError, urllib2.HTTPError) as error:
             self.logger.error("List of providers could not be retrieved.")
@@ -117,7 +117,7 @@ class CloudRecordView(APIView):
             self.logger.info("Host %s is banned.", signer)
             return False
 
-        providers = self._get_provider_list()
+        providers = self._get_provider_json_indigo_cmdb()
 
         try:
             # Extract the site JSON objects from the returned JSON

--- a/api/views/CloudRecordView.py
+++ b/api/views/CloudRecordView.py
@@ -135,6 +135,13 @@ class CloudRecordView(APIView):
         # Return the hostnames we were able to extract.
         return provider_hostnames
 
+    def _get_indigo_providers(self):
+        """Return a list of registered INDIGO Resource Provider hostnames."""
+        # Get the JSON from the CMDB.
+        provider_json = self._get_provider_json_indigo_cmdb()
+        # Return any hostnames we can parse from the provider JSON.
+        return self._parse_hostnames_indigo_cmdb(provider_json)
+
     def _signer_is_valid(self, signer_dn):
         """Return True if signer's host is listed as a Resource Provider."""
         # Get the hostname from the DN
@@ -145,9 +152,7 @@ class CloudRecordView(APIView):
             self.logger.info("Host %s is banned.", signer)
             return False
 
-        provider_json = self._get_provider_json_indigo_cmdb()
-        provider_hosts = self._parse_hostnames_indigo_cmdb(provider_json)
-        if signer in provider_hosts:
+        if signer in self._get_indigo_providers():
             return True
 
         if signer_dn in settings.ALLOWED_TO_POST:


### PR DESCRIPTION
The lack of an available Indigo CMDB will cause POST requests to be denied even when the requester has been explicitly granted access in the `ALLOWED_TO_POST` variable.

This is caused by a failure to retrieve the provider JSON from an Indigo CMDB, which causes the method that determines whether the signer is valid (and by extension, whether the POST request should be authorized) to return false regardless of whether the signer has also been granted special access.

As the example Indigo CMDB is no longer accessible, all POST requests get denied.

This commit fixes that by making the method continue on to check the `ALLOWED_TO_POST` variable if the list of providers can't be retrieved.