### PR TITLE
Update developer deployment instructions

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -8,7 +8,7 @@ If you would like to contribute to the APEL REST interface.
 
 See [here](README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604) for instructions to run the Docker Images locally using docker-compose
 
-# Setup from source (on Centos 6)
+# Setup from source (on CentOS 7)
 We recommend this for development work ONLY.
 
 1. Install python, pip, mysql, apache, apache modules, trust bundle and other required RPMS for development.

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -35,8 +35,8 @@ We recommend this for development work ONLY.
 5. Create the database
     ```
     mysql -u root -e "create database apel_rest"
-    mysql -u root apel_rest < /var/www/html/schemas/cloud.sql
-    mysql -u root apel_rest < /var/www/html/schemas/cloud-extra.sql
+    mysql -u root apel_rest < /var/www/html/schemas/10-cloud.sql
+    mysql -u root apel_rest < /var/www/html/schemas/20-cloud-extra.sql
     ```
 
 6. Create a new, self signed, certificate

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -62,11 +62,11 @@ We recommend this for development work ONLY.
     ln -sf /var/www/html/conf/cloudsummariser.cfg /etc/apel/cloudsummariser.cfg
     ```
 
-9. Copy the script files
+9. Symlink the local script files into the appropriate places.  Note: these commands will override any existing scripts in those locations.
     ```
-    cp /var/www/html/scripts/cloudsummariser /etc/cron.d/cloudsummariser
-    cp /var/www/html/scripts/run_cloud_summariser.sh /usr/bin/run_cloud_summariser.sh
-    cp /var/www/html/scripts/apeldbloader-cloud /etc/init.d/apeldbloader-cloud
+    ln -sf /var/www/html/scripts/cloudsummariser /etc/cron.d/cloudsummariser
+    ln -sf /var/www/html/scripts/run_cloud_summariser.sh /usr/bin/run_cloud_summariser.sh
+    ln -sf /var/www/html/scripts/apeldbloader-cloud /etc/init.d/apeldbloader-cloud
     ```
 
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -13,7 +13,7 @@ We recommend this for development work ONLY.
 
 1. Install python, pip, mysql, apache, apache modules, trust bundle and other required RPMS for development.
     ```
-    yum -y install python-pip python-devel mysql mysql-devel gcc httpd httpd-devel mod_wsgi mod_ssl cronie at ca-policy-egi-core fetch-crl python-iso8601 python-ldap git bash-completion tree
+    yum -y install python-pip python-devel mysql-server mysql mysql-devel gcc httpd httpd-devel mod_wsgi mod_ssl cronie at ca-policy-egi-core fetch-crl python-iso8601 python-ldap git bash-completion tree
     ```
     
 2. Upgrade pip and setuptools

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -62,6 +62,7 @@ We recommend this for development work ONLY.
 
 9. To allow successful GET requests, you will need to register your APEL REST instance with the Indigo DataCloud IAM and add IAM variables in `/var/www/html/apel_rest/settings.py`. You will also need to register a second service (the querying test service), and authorise it by adding it's ID to `ALLOWED_FOR_GET`
     ```
+    IAM_HOSTNAME_LIST=
     SERVER_IAM_ID=
     SERVER_IAM_SECRET=
     ALLOWED_FOR_GET=

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -72,4 +72,4 @@ We recommend this for development work ONLY.
 
 11. Start Apache with `service httpd start`
 
-12. Navigate a web browser to "https://<hostname>/api/v1/cloud/record/summary/"
+12. Navigate a web browser to "https://<hostname>/api/v1/cloud/record/summary"

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -58,28 +58,17 @@ We recommend this for development work ONLY.
     ```
     ln -sf /var/www/html/conf/apel_rest_api.conf /etc/httpd/conf.d/apel_rest_api.conf
     ln -sf /var/www/html/conf/ssl.conf /etc/httpd/conf.d/ssl.conf
-    ln -sf /var/www/html/conf/cloudloader.cfg /etc/apel/cloudloader.cfg
-    ln -sf /var/www/html/conf/cloudsummariser.cfg /etc/apel/cloudsummariser.cfg
     ```
 
-9. Symlink the local script files into the appropriate places.  Note: these commands will override any existing scripts in those locations.
-    ```
-    ln -sf /var/www/html/scripts/cloudsummariser /etc/cron.d/cloudsummariser
-    ln -sf /var/www/html/scripts/run_cloud_summariser.sh /usr/bin/run_cloud_summariser.sh
-    ln -sf /var/www/html/scripts/apeldbloader-cloud /etc/init.d/apeldbloader-cloud
-    ```
-
-10. To allow successful GET requests, you will need to register your APEL REST instance with the Indigo DataCloud IAM and add IAM variables in `/var/www/html/apel_rest/settings.py`. You will also need to register a second service (the querying test service), and authorise it by adding it's ID to `ALLOWED_FOR_GET`
+9. To allow successful GET requests, you will need to register your APEL REST instance with the Indigo DataCloud IAM and add IAM variables in `/var/www/html/apel_rest/settings.py`. You will also need to register a second service (the querying test service), and authorise it by adding it's ID to `ALLOWED_FOR_GET`
     ```
     SERVER_IAM_ID=
     SERVER_IAM_SECRET=
     ALLOWED_FOR_GET=
     ```
 
-11. Run `python manage.py collectstatic`
+10. Run `python manage.py collectstatic`
 
-12. Start Apache with `service httpd start`
+11. Start Apache with `service httpd start`
 
-13. Start the loader with `service apeldbloader-cloud start`
-
-14. Navigate a web browser to "https://<hostname>/api/v1/cloud/record/summary/"
+12. Navigate a web browser to "https://<hostname>/api/v1/cloud/record/summary/"

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -45,7 +45,16 @@ We recommend this for development work ONLY.
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/httpd/ssl/apache.key -out /etc/httpd/ssl/apache.crt
     ```
 
-7. Symlink the local config files into the `/etc` directory. Note: these commands will override any existing configurations in those locations.
+7. Create etc, log, run and spool directories
+   ```
+   mkdir /etc/apel
+   mkdir /var/log/cloud
+   mkdir /var/run/cloud
+   mkdir -p /var/spool/apel/cloud/
+   chown apache -R /var/spool/apel/cloud/
+   ```
+
+8. Symlink the local config files into the `/etc` directory. Note: these commands will override any existing configurations in those locations.
     ```
     ln -sf /var/www/html/conf/apel_rest_api.conf /etc/httpd/conf.d/apel_rest_api.conf
     ln -sf /var/www/html/conf/ssl.conf /etc/httpd/conf.d/ssl.conf
@@ -53,20 +62,13 @@ We recommend this for development work ONLY.
     ln -sf /var/www/html/conf/cloudsummariser.cfg /etc/apel/cloudsummariser.cfg
     ```
 
-8. Copy the script files
+9. Copy the script files
     ```
     cp /var/www/html/scripts/cloudsummariser /etc/cron.d/cloudsummariser
     cp /var/www/html/scripts/run_cloud_summariser.sh /usr/bin/run_cloud_summariser.sh
     cp /var/www/html/scripts/apeldbloader-cloud /etc/init.d/apeldbloader-cloud
     ```
 
-9. Create log, run and spool directories
-   ```
-   mkdir /var/log/cloud
-   mkdir /var/run/cloud
-   mkdir -p /var/spool/apel/cloud/
-   chown apache -R /var/spool/apel/cloud/
-   ```
 
 10. To allow successful GET requests, you will need to register your APEL REST instance with the Indigo DataCloud IAM and add IAM variables in `/var/www/html/apel_rest/settings.py`. You will also need to register a second service (the querying test service), and authorise it by adding it's ID to `ALLOWED_FOR_GET`
     ```

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -68,7 +68,7 @@ We recommend this for development work ONLY.
     ALLOWED_FOR_GET=
     ```
 
-10. Run `python manage.py collectstatic`
+10. Run `python /var/www/html/manage.py collectstatic`
 
 11. Start Apache with `service httpd start`
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -45,12 +45,12 @@ We recommend this for development work ONLY.
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/httpd/ssl/apache.key -out /etc/httpd/ssl/apache.crt
     ```
 
-7. Copy the configuration files
+7. Symlink the local config files into the `/etc` directory. Note: these commands will override any existing configurations in those locations.
     ```
-    cp /var/www/html/conf/apel_rest_api.conf /etc/httpd/conf.d/apel_rest_api.conf
-    cp /var/www/html/conf/ssl.conf /etc/httpd/conf.d/ssl.conf
-    cp /var/www/html/conf/cloudloader.cfg /etc/apel/cloudloader.cfg
-    cp /var/www/html/conf/cloudsummariser.cfg /etc/apel/cloudsummariser.cfg
+    ln -sf /var/www/html/conf/apel_rest_api.conf /etc/httpd/conf.d/apel_rest_api.conf
+    ln -sf /var/www/html/conf/ssl.conf /etc/httpd/conf.d/ssl.conf
+    ln -sf /var/www/html/conf/cloudloader.cfg /etc/apel/cloudloader.cfg
+    ln -sf /var/www/html/conf/cloudsummariser.cfg /etc/apel/cloudsummariser.cfg
     ```
 
 8. Copy the script files

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -29,7 +29,7 @@ We recommend this for development work ONLY.
 
 4. Install requirements.txt
     ```
-    pip install -r requirements.txt
+    pip install -r /var/www/html/requirements.txt
     ```
 
 5. Create the database

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -22,14 +22,14 @@ We recommend this for development work ONLY.
     pip install setuptools --upgrade
     ```
     
-3. Install requirements.txt
-    ```
-    pip install -r requirements.txt
-    ```
-
-4. Clone the repo to `/var/www/html`
+3. Clone the repo to `/var/www/html
     ```
     git clone https://github.com/apel/rest.git /var/www/html
+    ```
+
+4. Install requirements.txt
+    ```
+    pip install -r requirements.txt
     ```
 
 5. Create the database

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -73,3 +73,20 @@ We recommend this for development work ONLY.
 11. Start Apache with `service httpd start`
 
 12. Navigate a web browser to `https://<hostname>/api/v1/cloud/record/summary`
+
+## Optional: Set up a Docker-ized version of the APEL Server
+
+Deploying an APEL Server along with the REST interface and database is not necessary, but is useful for allowing data to flow from input via the REST interface to summarised output via the REST interface. For the purposes of developing the APEL Rest interface we treat the APEL Server as a 'black box', so we recommend deploying it as a Docker image.
+
+You will need to install Docker and Docker Compose first, see the [README.md](../README.md) for a link to the instructions.
+
+Then:
+
+1. Follow step 7 in the [README.md](../README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604).
+
+2. Modify `docker/etc/apel/clouddb.cfg` so that the host with the database is `localhost`.
+
+3. Run `docker-compose -f yaml/docker-compose.yaml run -v /var/lib/mysql:/var/lib/mysql -d --no-deps apel_server`
+
+You should now have a running instance of the Docker-ized APEL Server, capable of talking to your development REST interface and database.
+

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -71,11 +71,13 @@ We recommend this for development work ONLY.
     ALLOWED_FOR_GET=
     ```
 
-10. Run `python /var/www/html/manage.py collectstatic`
+10. To allow successful POST requests, you will need to add the DN of a CA-Signed certificate that you have access to (either a personal certificate or a host certificate) to `ALLOWED_FOR_POST` in `/var/www/html/apel_rest/settings.py`
 
-11. Start Apache with `service httpd start`
+11. Run `python /var/www/html/manage.py collectstatic`
 
-12. Navigate a web browser to `https://<hostname>/api/v1/cloud/record/summary`
+12. Start Apache with `service httpd start`
+
+13. Navigate a web browser to `https://<hostname>/api/v1/cloud/record/summary`
 
 ## Optional: Set up a Docker-ized version of the APEL Server
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -35,8 +35,8 @@ We recommend this for development work ONLY.
 5. Create the database
     ```
     mysql -u root -e "create database apel_rest"
-    mysql -u root apel_rest < schemas/cloud.sql
-    mysql -u root apel_rest < schemas/cloud-extra.sql
+    mysql -u root apel_rest < /var/www/html/schemas/cloud.sql
+    mysql -u root apel_rest < /var/www/html/schemas/cloud-extra.sql
     ```
 
 6. Create a new, self signed, certificate

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -34,9 +34,12 @@ We recommend this for development work ONLY.
 
 5. Create the database
     ```
-    mysql -u root -e "create database apel_rest"
-    mysql -u root apel_rest < /var/www/html/schemas/10-cloud.sql
-    mysql -u root apel_rest < /var/www/html/schemas/20-cloud-extra.sql
+    mysql -u root -e "create user 'apel'@'localhost';"
+    mysql -u root -e "GRANT ALL PRIVILEGES ON apel_rest.* TO 'apel'@'localhost';"
+    mysql -u root -e "FLUSH PRIVILEGES;"
+    mysql -u apel -e "create database apel_rest"
+    mysql -u apel apel_rest < /var/www/html/schemas/10-cloud.sql
+    mysql -u apel apel_rest < /var/www/html/schemas/20-cloud-extra.sql
     ```
 
 6. Create a new, self signed, certificate
@@ -78,7 +81,7 @@ We recommend this for development work ONLY.
 
 Deploying an APEL Server along with the REST interface and database is not necessary, but is useful for allowing data to flow from input via the REST interface to summarised output via the REST interface. For the purposes of developing the APEL Rest interface we treat the APEL Server as a 'black box', so we recommend deploying it as a Docker image.
 
-You will need to install Docker and Docker Compose first, see the [README.md](../README.md) for a link to the instructions.
+You will need to install Docker and Docker Compose first, see the [README.md](../README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604) for a link to the instructions.
 
 Then:
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -85,11 +85,13 @@ You will need to install Docker and Docker Compose first, see the [README.md](..
 
 Then:
 
-1. Follow step 7 in the [README.md](../README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604).
+1. cd into `/var/www/html`
 
-2. Modify `docker/etc/apel/clouddb.cfg` so that the host with the database is `localhost`.
+2. Follow step 7 in the [README.md](../README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604).
 
-3. Run `docker-compose -f yaml/docker-compose.yaml run -v /var/lib/mysql:/var/lib/mysql -d --no-deps apel_server`
+3. Modify `docker/etc/apel/clouddb.cfg` so that the host with the database is `localhost`.
+
+4. Run `docker-compose -f yaml/docker-compose.yaml run -v /var/lib/mysql:/var/lib/mysql -d --no-deps apel_server`
 
 You should now have a running instance of the Docker-ized APEL Server, capable of talking to your development REST interface and database.
 

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -69,7 +69,6 @@ We recommend this for development work ONLY.
     ln -sf /var/www/html/scripts/apeldbloader-cloud /etc/init.d/apeldbloader-cloud
     ```
 
-
 10. To allow successful GET requests, you will need to register your APEL REST instance with the Indigo DataCloud IAM and add IAM variables in `/var/www/html/apel_rest/settings.py`. You will also need to register a second service (the querying test service), and authorise it by adding it's ID to `ALLOWED_FOR_GET`
     ```
     SERVER_IAM_ID=

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -72,4 +72,4 @@ We recommend this for development work ONLY.
 
 11. Start Apache with `service httpd start`
 
-12. Navigate a web browser to "https://<hostname>/api/v1/cloud/record/summary"
+12. Navigate a web browser to `https://<hostname>/api/v1/cloud/record/summary`


### PR DESCRIPTION
- Specify the preferred OS as `CentOS 7` (not `CentOS 6`)
- Add the missing requirement of `mysql-server`
- Suggest sym-linking config files rather than manually copying them to avoid errors where changes to the configuration are not reflected in the running development instance.
- Reflect the fact that the APEL server and the REST interface are now completely separate (when the original documentation was written they were much closer) and add instructions for deploying an APEL server as a 'black box' using the docker deployment.