### PR TITLE
Move Django files to reflect the suggestions of the Django documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ gpgkey=http://repository.egi.eu/sw/production/cas/1/GPG-KEY-EUGridPMA-RPM-3' >> 
 RUN yum -y install python-pip python-devel mysql mysql-devel gcc httpd httpd-devel mod_wsgi mod_ssl cronie at ca-policy-egi-core fetch-crl
 
 # Copy APEL REST files to apache root
-COPY . /var/www/html/
+COPY . /home/apel_rest_interface
 
-# Set the work diirectory to /var/www/html
-WORKDIR /var/www/html
+# Set the work diirectory to /home/apel_rest_interface
+WORKDIR /home/apel_rest_interface
 
 # Install APEL REST requirements
 RUN pip install -r requirements.txt

--- a/apel_rest/settings.py
+++ b/apel_rest/settings.py
@@ -84,7 +84,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
-STATIC_ROOT = '/var/www/html/static'
+STATIC_ROOT = '/var/www/static'
 STATIC_URL = '/static/'
 
 # debugging stuff

--- a/conf/apel_rest_api.conf
+++ b/conf/apel_rest_api.conf
@@ -15,7 +15,7 @@ WSGIProcessGroup apel_rest
 WSGIScriptAlias / /home/apel_rest_interface/apel_rest/wsgi.py
 WSGIPassAuthorization On
 
-Alias /static "/usr/lib/python2.7/site-packages/rest_framework/static"
-<Directory "/usr/lib/python2.7/site-packages/rest_framework/static">
+Alias /static "/var/www/static"
+<Directory "/var/www/static">
 Require all granted
 </Directory>

--- a/conf/apel_rest_api.conf
+++ b/conf/apel_rest_api.conf
@@ -3,16 +3,16 @@ RewriteCond %{HTTPS} off
 RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization},L]
 
-<Directory /var/www/html/apel_rest>
+<Directory /home/apel_rest_interface/apel_rest>
 <Files wsgi.py>
 Require all granted
 </Files>
 </Directory>
 
 WSGISocketPrefix /var/run/wsgi
-WSGIDaemonProcess apel_rest python-path=/var/www/html:/usr/lib/python2.6/site-packages
+WSGIDaemonProcess apel_rest python-path=/home/apel_rest_interface:/usr/lib/python2.6/site-packages
 WSGIProcessGroup apel_rest
-WSGIScriptAlias / /var/www/html/apel_rest/wsgi.py
+WSGIScriptAlias / /home/apel_rest_interface/apel_rest/wsgi.py
 WSGIPassAuthorization On
 
 Alias /static "/usr/lib/python2.7/site-packages/rest_framework/static"

--- a/conf/apel_rest_api.conf
+++ b/conf/apel_rest_api.conf
@@ -10,7 +10,7 @@ Require all granted
 </Directory>
 
 WSGISocketPrefix /var/run/wsgi
-WSGIDaemonProcess apel_rest python-path=/home/apel_rest_interface:/usr/lib/python2.6/site-packages
+WSGIDaemonProcess apel_rest python-path=/home/apel_rest_interface
 WSGIProcessGroup apel_rest
 WSGIScriptAlias / /home/apel_rest_interface/apel_rest/wsgi.py
 WSGIPassAuthorization On

--- a/doc/developer.md
+++ b/doc/developer.md
@@ -22,14 +22,14 @@ We recommend this for development work ONLY.
     pip install setuptools --upgrade
     ```
     
-3. Clone the repo to `/var/www/html
+3. Clone the repo to `/home/apel_rest_interface`
     ```
-    git clone https://github.com/apel/rest.git /var/www/html
+    git clone https://github.com/apel/rest.git /home/apel_rest_interface
     ```
 
 4. Install requirements.txt
     ```
-    pip install -r /var/www/html/requirements.txt
+    pip install -r /home/apel_rest_interface/requirements.txt
     ```
 
 5. Create the database
@@ -38,8 +38,8 @@ We recommend this for development work ONLY.
     mysql -u root -e "GRANT ALL PRIVILEGES ON apel_rest.* TO 'apel'@'localhost';"
     mysql -u root -e "FLUSH PRIVILEGES;"
     mysql -u apel -e "create database apel_rest"
-    mysql -u apel apel_rest < /var/www/html/schemas/10-cloud.sql
-    mysql -u apel apel_rest < /var/www/html/schemas/20-cloud-extra.sql
+    mysql -u apel apel_rest < /home/apel_rest_interface/schemas/10-cloud.sql
+    mysql -u apel apel_rest < /home/apel_rest_interface/schemas/20-cloud-extra.sql
     ```
 
 6. Create a new, self signed, certificate
@@ -59,11 +59,11 @@ We recommend this for development work ONLY.
 
 8. Symlink the local config files into the `/etc` directory. Note: these commands will override any existing configurations in those locations.
     ```
-    ln -sf /var/www/html/conf/apel_rest_api.conf /etc/httpd/conf.d/apel_rest_api.conf
-    ln -sf /var/www/html/conf/ssl.conf /etc/httpd/conf.d/ssl.conf
+    ln -sf /home/apel_rest_interface/conf/apel_rest_api.conf /etc/httpd/conf.d/apel_rest_api.conf
+    ln -sf /home/apel_rest_interface/conf/ssl.conf /etc/httpd/conf.d/ssl.conf
     ```
 
-9. To allow successful GET requests, you will need to register your APEL REST instance with the Indigo DataCloud IAM and add IAM variables in `/var/www/html/apel_rest/settings.py`. You will also need to register a second service (the querying test service), and authorise it by adding it's ID to `ALLOWED_FOR_GET`
+9. To allow successful GET requests, you will need to register your APEL REST instance with the Indigo DataCloud IAM and add IAM variables in `/home/apel_rest_interface/apel_rest/settings.py`. You will also need to register a second service (the querying test service), and authorise it by adding it's ID to `ALLOWED_FOR_GET`
     ```
     IAM_HOSTNAME_LIST=
     SERVER_IAM_ID=
@@ -71,9 +71,9 @@ We recommend this for development work ONLY.
     ALLOWED_FOR_GET=
     ```
 
-10. To allow successful POST requests, you will need to add the DN of a CA-Signed certificate that you have access to (either a personal certificate or a host certificate) to `ALLOWED_FOR_POST` in `/var/www/html/apel_rest/settings.py`
+10. To allow successful POST requests, you will need to add the DN of a CA-Signed certificate that you have access to (either a personal certificate or a host certificate) to `ALLOWED_FOR_POST` in `/home/apel_rest_interface/apel_rest/settings.py`
 
-11. Run `python /var/www/html/manage.py collectstatic`
+11. Run `python /home/apel_rest_interface/manage.py collectstatic`
 
 12. Start Apache with `service httpd start`
 
@@ -87,7 +87,7 @@ You will need to install Docker and Docker Compose first, see the [README.md](..
 
 Then:
 
-1. cd into `/var/www/html`
+1. cd into `/home/apel_rest_interface`
 
 2. Follow step 7 in the [README.md](../README.md#running-the-docker-image-on-centos-7-and-ubuntu-1604).
 

--- a/docker/run_on_entry.sh
+++ b/docker/run_on_entry.sh
@@ -2,28 +2,28 @@
 
 # Replace locally configured variables in apel_rest
 #SECRET_KEY
-sed -i "s|not_a_secure_secret|$DJANGO_SECRET_KEY|g" /var/www/html/apel_rest/settings.py
+sed -i "s|not_a_secure_secret|$DJANGO_SECRET_KEY|g" /home/apel_rest_interface/apel_rest/settings.py
 
 #PROVIDERS_URL
-sed -i "s|provider_url|$PROVIDERS_URL|g" /var/www/html/apel_rest/settings.py
+sed -i "s|provider_url|$PROVIDERS_URL|g" /home/apel_rest_interface/apel_rest/settings.py
 
 # IAM_URL
-sed -i "s|\['allowed_iams'\]|$IAM_URLS|g" /var/www/html/apel_rest/settings.py
+sed -i "s|\['allowed_iams'\]|$IAM_URLS|g" /home/apel_rest_interface/apel_rest/settings.py
 
 # SERVER_IAM_ID
-sed -i "s|server_iam_id|$SERVER_IAM_ID|g" /var/www/html/apel_rest/settings.py
+sed -i "s|server_iam_id|$SERVER_IAM_ID|g" /home/apel_rest_interface/apel_rest/settings.py
 
 # SERVER_IAM_SECRET
-sed -i "s|server_iam_secret|$SERVER_IAM_SECRET|g" /var/www/html/apel_rest/settings.py
+sed -i "s|server_iam_secret|$SERVER_IAM_SECRET|g" /home/apel_rest_interface/apel_rest/settings.py
 
 # ALLOWED_TO_POST
-sed -i "s|\['allowed_to_post'\]|$ALLOWED_TO_POST|g" /var/www/html/apel_rest/settings.py
+sed -i "s|\['allowed_to_post'\]|$ALLOWED_TO_POST|g" /home/apel_rest_interface/apel_rest/settings.py
 
 # BANNED_FROM_POST
-sed -i "s|\['banned_from_post'\]|$BANNED_FROM_POST|g" /var/www/html/apel_rest/settings.py
+sed -i "s|\['banned_from_post'\]|$BANNED_FROM_POST|g" /home/apel_rest_interface/apel_rest/settings.py
 
 # ALLOWED_FOR_GET
-sed -i "s|\['allowed_for_get'\]|$ALLOWED_FOR_GET|g" /var/www/html/apel_rest/settings.py
+sed -i "s|\['allowed_for_get'\]|$ALLOWED_FOR_GET|g" /home/apel_rest_interface/apel_rest/settings.py
 
 
 # fetch the crl first


### PR DESCRIPTION
Resolves #51 

- Move the Django app from `/var/www/html` to `/home/apel_rest_interface` as per the [documentation](https://docs.djangoproject.com/en/1.7/intro/tutorial01/#creating-a-project).
- Move static files from `var/www/html/static` to `/var/www/static` as per the [documentation](https://docs.djangoproject.com/en/1.7/howto/static-files/#configuring-static-files) for non app specific static files.
- Remove `site-packages` from `WSGIDaemonProcess` in the apache conf as the path is wrong and no needing according to the [documentation](https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/modwsgi/#using-mod-wsgi-daemon-mode).

This PR also updates `Dockerbuild`, the `docker/run_on_entry.sh` script and the developer documentation to refelct these chnages.