### PR TITLE
Update versions in requirements.txt and remove deprecated feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "nightly"
 matrix:

--- a/apel_rest/urls.py
+++ b/apel_rest/urls.py
@@ -1,24 +1,25 @@
 """This file maps url patterns to classes."""
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from django.contrib import admin
 from api.views.CloudRecordSummaryView import CloudRecordSummaryView
 from api.views.CloudRecordView import CloudRecordView
+
 admin.autodiscover()
 
-urlpatterns = patterns('',
-                       # Examples:
-                       # url(r'^$', 'apel_rest.views.home', name='home'),
-                       # url(r'^blog/', include('blog.urls')),
+urlpatterns = [
+               # Examples:
+               # url(r'^$', 'apel_rest.views.home', name='home'),
+               # url(r'^blog/', include('blog.urls')),
 
-                       url(r'^admin/',
-                           include(admin.site.urls)),
+               url(r'^admin/', include(admin.site.urls)),
 
-                       url(r'^api/v1/cloud/record$',
-                           CloudRecordView.as_view(),
-                           name='CloudRecordView'),
+               url(r'^api/v1/cloud/record$',
+                   CloudRecordView.as_view(),
+                   name='CloudRecordView'),
 
-                       url(r'^api/v1/cloud/record/summary$',
-                           CloudRecordSummaryView.as_view(),
-                           name='CloudRecordSummaryView'))
+               url(r'^api/v1/cloud/record/summary$',
+                   CloudRecordSummaryView.as_view(),
+                   name='CloudRecordSummaryView')
+]

--- a/api/views/CloudRecordSummaryView.py
+++ b/api/views/CloudRecordSummaryView.py
@@ -1,6 +1,9 @@
 """This file contains the CloudRecordSummaryView class."""
 
-import ConfigParser
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 import datetime
 import logging
 import MySQLdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dirq
 django==1.11.20
-djangorestframework==3.0.5
+djangorestframework==3.9.4
 python-jose<3.0.0
 MySQL-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dirq
-django==1.6.3
+django==1.11.20
 djangorestframework==3.0.5
 python-jose<3.0.0
 MySQL-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dirq
 django==1.11.20
 djangorestframework==3.9.4
 python-jose<3.0.0
-MySQL-python
+mysqlclient==1.3.4


### PR DESCRIPTION
Update Django and rest framework versions in `requirements.txt` as current versions listed have security vulnerabilities. Also remote `patterns()` as that is deprecated in this later version.